### PR TITLE
Rename “轻轨” to “轻铁”

### DIFF
--- a/src/i18n/translations/zh-Hans.json
+++ b/src/i18n/translations/zh-Hans.json
@@ -300,7 +300,7 @@
                     "displayName": "香港MTR赛马日样式"
                 },
                 "mtrLightRail": {
-                    "displayName": "香港MTR轻轨样式"
+                    "displayName": "香港MTR轻铁样式"
                 },
                 "mtrUnpaidArea": {
                     "displayName": "香港MTR未付费区域样式"

--- a/src/i18n/translations/zh-Hant.json
+++ b/src/i18n/translations/zh-Hant.json
@@ -300,7 +300,7 @@
                     "displayName": "香港MTR賽馬日樣式"
                 },
                 "mtrLightRail": {
-                    "displayName": "香港MTR輕軌樣式"
+                    "displayName": "香港MTR輕鐵樣式"
                 },
                 "mtrUnpaidArea": {
                     "displayName": "香港MTR未付費區域樣式"


### PR DESCRIPTION
如图，这是轻铁35周年时，车辆显示屏显示为“轻铁“ ，香港从来没有“轻轨”的称呼，因此改为官方名“轻铁”较为合适
![IMG_5652](https://github.com/railmapgen/rmp/assets/132824071/bb4784cd-7a1a-4c51-872a-0a311e55735f)
