### PR TITLE
#895 Import from rmg should follow it's logical order instead of array index

### DIFF
--- a/src/components/page-header/open-actions.tsx
+++ b/src/components/page-header/open-actions.tsx
@@ -4,25 +4,22 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { MdInsertDriveFile, MdNoteAdd, MdOpenInNew, MdSchool, MdUpload } from 'react-icons/md';
 import { Events, LocalStorageKey } from '../../constants/constants';
-import { RMGParam } from '../../constants/rmg';
-import { useRootDispatch, useRootSelector } from '../../redux';
+import { useRootDispatch } from '../../redux';
 import { saveGraph, setSvgViewBoxMin, setSvgViewBoxZoom } from '../../redux/param/param-slice';
 import { clearSelected, refreshEdgesThunk, refreshNodesThunk, setGlobalAlert } from '../../redux/runtime/runtime-slice';
 import { getCanvasSize } from '../../util/helpers';
 import { useWindowSize } from '../../util/hooks';
-import { parseRmgParam } from '../../util/rmg-param-parser';
 import { saveManagerChannel, SaveManagerEvent, SaveManagerEventType } from '../../util/rmt-save';
 import { getInitialParam, RMPSave, upgrade } from '../../util/save';
 import RmgParamAppClip from './rmg-param-app-clip';
 import RmpGalleryAppClip from './rmp-gallery-app-clip';
 
 export default function OpenActions() {
-    const { t } = useTranslation();
     const dispatch = useRootDispatch();
-    const {
-        preference: { autoParallel },
-    } = useRootSelector(state => state.app);
-    const isAllowAppTelemetry = rmgRuntime.isAllowAnalytics();
+    const { t } = useTranslation();
+
+    const size = useWindowSize();
+    const { height } = getCanvasSize(size);
 
     const graph = React.useRef(window.graph);
     const fileInputRef = React.useRef<HTMLInputElement | null>(null);
@@ -42,19 +39,6 @@ export default function OpenActions() {
         dispatch(setSvgViewBoxZoom(100));
         dispatch(setSvgViewBoxMin({ x: 0, y: 0 }));
         refreshAndSave();
-    };
-
-    const handleImportRMGProject = (param: RMGParam) => {
-        try {
-            if (isAllowAppTelemetry) rmgRuntime.event(Events.IMPORT_RMG_PARAM, {});
-            parseRmgParam(graph.current, param, autoParallel);
-            refreshAndSave();
-        } catch (err) {
-            dispatch(setGlobalAlert({ status: 'error', message: t('header.open.unknownError') }));
-            console.error('OpenActions.handleUploadRMG():: Unknown error occurred while parsing the RMG project', err);
-        } finally {
-            setIsRmgParamAppClipOpen(false);
-        }
     };
 
     const loadParam = async (paramStr: string) => {
@@ -131,9 +115,6 @@ export default function OpenActions() {
         return () => saveManagerChannel.removeEventListener('message', rmtSaveHandler);
     }, []);
 
-    const size = useWindowSize();
-    const { height } = getCanvasSize(size);
-
     return (
         <Menu>
             <MenuButton as={IconButton} size="sm" variant="ghost" icon={<MdUpload />} />
@@ -171,11 +152,7 @@ export default function OpenActions() {
                 </MenuItem>
             </MenuList>
 
-            <RmgParamAppClip
-                isOpen={isRmgParamAppClipOpen}
-                onClose={() => setIsRmgParamAppClipOpen(false)}
-                onImport={handleImportRMGProject}
-            />
+            <RmgParamAppClip isOpen={isRmgParamAppClipOpen} onClose={() => setIsRmgParamAppClipOpen(false)} />
             <RmpGalleryAppClip isOpen={isOpenGallery} onClose={() => setIsOpenGallery(false)} />
         </Menu>
     );

--- a/src/components/page-header/rmg-param-app-clip.tsx
+++ b/src/components/page-header/rmg-param-app-clip.tsx
@@ -1,8 +1,16 @@
 import { SystemStyleObject } from '@chakra-ui/react';
-import { useEffect, useState } from 'react';
-import rmgRuntime from '@railmapgen/rmg-runtime';
 import { RmgAppClip } from '@railmapgen/rmg-components';
+import rmgRuntime from '@railmapgen/rmg-runtime';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Events } from '../../constants/constants';
 import { RMGParam } from '../../constants/rmg';
+import { useRootDispatch, useRootSelector } from '../../redux';
+import { saveGraph } from '../../redux/param/param-slice';
+import { refreshEdgesThunk, refreshNodesThunk, setGlobalAlert } from '../../redux/runtime/runtime-slice';
+import { getCanvasSize } from '../../util/helpers';
+import { useWindowSize } from '../../util/hooks';
+import { parseRmgParam } from '../../util/rmg-param-parser';
 
 const CHANNEL_PREFIX = 'rmg-bridge--';
 
@@ -19,11 +27,23 @@ const styles: SystemStyleObject = {
 interface RmgAppClipProps {
     isOpen: boolean;
     onClose: () => void;
-    onImport: (param: RMGParam) => void;
 }
 
 export default function RmgParamAppClip(props: RmgAppClipProps) {
-    const { isOpen, onClose, onImport } = props;
+    const { isOpen, onClose } = props;
+    const { t } = useTranslation();
+
+    const {
+        preference: { autoParallel },
+    } = useRootSelector(state => state.app);
+    const { svgViewBoxZoom, svgViewBoxMin } = useRootSelector(state => state.param);
+    const dispatch = useRootDispatch();
+    const isAllowAppTelemetry = rmgRuntime.isAllowAnalytics();
+
+    const size = useWindowSize();
+    const { height, width } = getCanvasSize(size);
+
+    const graph = useRef(window.graph);
 
     const [appClipId] = useState(crypto.randomUUID());
     const frameUrl =
@@ -33,6 +53,27 @@ export default function RmgParamAppClip(props: RmgAppClipProps) {
             parentId: appClipId,
         });
 
+    const refreshAndSave = useCallback(() => {
+        dispatch(refreshNodesThunk());
+        dispatch(refreshEdgesThunk());
+        dispatch(saveGraph(graph.current.export()));
+    }, [dispatch, refreshNodesThunk, refreshEdgesThunk, saveGraph, graph]);
+
+    const handleImportRMGProject = (param: RMGParam) => {
+        try {
+            if (isAllowAppTelemetry) rmgRuntime.event(Events.IMPORT_RMG_PARAM, {});
+            const x = svgViewBoxMin.x + (width * svgViewBoxZoom) / 100 / 3;
+            const y = svgViewBoxMin.y + (height * svgViewBoxZoom) / 100 / 3;
+            parseRmgParam(graph.current, param, x, y, autoParallel);
+            refreshAndSave();
+        } catch (err) {
+            dispatch(setGlobalAlert({ status: 'error', message: t('header.open.unknownError') }));
+            console.error('OpenActions.handleUploadRMG():: Unknown error occurred while parsing the RMG project', err);
+        } finally {
+            onClose();
+        }
+    };
+
     useEffect(() => {
         const channel = new BroadcastChannel(CHANNEL_PREFIX + appClipId);
         channel.onmessage = ev => {
@@ -41,11 +82,11 @@ export default function RmgParamAppClip(props: RmgAppClipProps) {
             if (event === 'CLOSE') {
                 onClose();
             } else if (event === 'IMPORT') {
-                onImport(data as RMGParam);
+                handleImportRMGProject(data as RMGParam);
             }
         };
         return () => channel.close();
-    }, []);
+    }, [svgViewBoxMin.x, svgViewBoxMin.y, svgViewBoxZoom, height, width, autoParallel]);
 
     return (
         <RmgAppClip isOpen={isOpen} onClose={onClose} sx={styles}>

--- a/src/util/rmg-param-parser.ts
+++ b/src/util/rmg-param-parser.ts
@@ -13,9 +13,19 @@ import { PanelTypeShmetro, RMGParam, RmgStyle } from '../constants/rmg';
 import { StationAttributes, StationType } from '../constants/stations';
 import { makeParallelIndex } from './parallel';
 
+/**
+ * Prase the rmg save format and add nodes/edges in the graph.
+ * @param graph The only global graph.
+ * @param rmgParam The rmg save in RMGParam type.
+ * @param x The current cavans center point (x).
+ * @param y The current cavans center point (y).
+ * @param autoParallel Whether to enable auto parallel.
+ */
 export const parseRmgParam = (
     graph: MultiDirectedGraph<NodeAttributes, EdgeAttributes, GraphAttributes>,
     { info_panel_type, line_num, stn_list: stnList, style, theme }: RMGParam,
+    x: number,
+    y: number,
     autoParallel: boolean
 ) => {
     // generate stn id
@@ -35,6 +45,27 @@ export const parseRmgParam = (
             );
             if (nodes.length !== 0) stnIdMap[id] = nodes[0] as StnId;
         });
+    // BFS to calculate the coordination of each station, so that first stations come first
+    //
+    // note stations might be calculated multiple times if branches exist,
+    // this makes sure station on the main branch will always be right to
+    // stations on both branches (one might be long but the short one will
+    // queue stations in the main branches first, this will result in
+    // overlapped stations between long branch and mian branch)
+    const coordQueue: [string, number, number][] = [['linestart', -1, 0]];
+    const stnIdCoord: { [k: string]: { x: number; y: number } } = {};
+    while (coordQueue.length) {
+        const [cur, x, y] = coordQueue.shift()!;
+        const children = stnList[cur].children;
+        children
+            .filter(child => child != 'lineend')
+            .forEach((child, i) => {
+                // this temp y makes each branch on seperate horizontal level
+                const _ = Math.max(i, y + i);
+                stnIdCoord[child] = { x: x * 150, y: _ * 75 };
+                coordQueue.push([child, x + 1, _]);
+            });
+    }
 
     // only import stations that does not exist in the graph, filter by name[0]
     Object.entries(stnList)
@@ -47,7 +78,7 @@ export const parseRmgParam = (
                         (attr[attr.type] as StationAttributes).names[0] === stnInfo.localisedName.zh
                 ).length === 0
         )
-        .forEach(([id, stnInfo], i) => {
+        .map(([id, stnInfo]) => {
             // determine station type
             let type: StationType = StationType.ShmetroBasic;
             const interchangeGroups = stnInfo.transfer.groups;
@@ -109,15 +140,19 @@ export const parseRmgParam = (
                 }
             }
 
-            graph.addNode(stnIdMap[id], {
-                visible: true,
-                zIndex: 0,
-                x: 100 + i * 50,
-                y: 1000,
-                type,
-                [type]: attr,
-            });
-        });
+            return {
+                node: stnIdMap[id],
+                attr: {
+                    visible: true,
+                    zIndex: 0,
+                    x: x + stnIdCoord[id].x,
+                    y: y + stnIdCoord[id].y,
+                    type,
+                    [type]: attr,
+                },
+            };
+        })
+        .forEach(({ node, attr }) => graph.addNode(node, attr));
 
     // import lines
     Object.entries(stnList)


### PR DESCRIPTION
We're passing some runtime variables to the parse and import rmg function.

Thus the function should not be passed to the component as it captures all the variables in the first load.
Also, the `onmessage` listener of the _broadcast channel_ should also be updated each time when the variables are __changed__.

Let me know if there is a better design choice here :)
