### PR TITLE
#985 Add textDistance to chongqingrt int

### DIFF
--- a/src/components/svgs/stations/chongqingrt-int-2021.tsx
+++ b/src/components/svgs/stations/chongqingrt-int-2021.tsx
@@ -336,7 +336,7 @@ const ChongqingRTInt2021AttrsComponent = (props: AttrsProps<ChongqingRTIntStatio
 const chongqingRTIntStation2021Icon = (
     <svg viewBox="-1 -1 22 22" height={40} width={40} focusable={false} style={{ padding: 5 }}>
         <g textAnchor="middle">
-            <rect x={0} y={0} width={20} height={20} stroke="black" strokeWidth={2} rx={2.5} ry={2.5} fill="none" />
+            <rect x={0} y={0} width={20} height={20} stroke="black" strokeWidth={2} rx={2.5} ry={2.5} fill="white" />
             <text fontSize={8} textAnchor="middle" x={10} y={9} fill="black">
                 两路
             </text>

--- a/src/components/svgs/stations/chongqingrt-int.tsx
+++ b/src/components/svgs/stations/chongqingrt-int.tsx
@@ -34,6 +34,7 @@ const ChongqingRTIntStation = (props: StationComponentProps) => {
         nameOffsetX = defaultChongqingRTIntStationAttributes.nameOffsetX,
         nameOffsetY = defaultChongqingRTIntStationAttributes.nameOffsetY,
         transfer = defaultChongqingRTIntStationAttributes.transfer,
+        textDistance = defaultChongqingRTIntStationAttributes.textDistance,
     } = attrs[StationType.ChongqingRTInt] ?? defaultChongqingRTIntStationAttributes;
 
     const onPointerDown = React.useCallback(
@@ -49,27 +50,30 @@ const ChongqingRTIntStation = (props: StationComponentProps) => {
         [id, handlePointerUp]
     );
 
-    const getTextOffset = (oX: NameOffsetX, oY: NameOffsetY) => {
+    const getTextOffset = (oX: NameOffsetX, oY: NameOffsetY, textDistance: TextDistance[]) => {
+        const offsetX = textDistance[0] == 'far' ? HALF_SIZE : 5;
+        const offsetY = textDistance[1] == 'far' ? HALF_SIZE : textDistance[0] == 'far' ? 5 : 7;
+        const offsetM = HALF_SIZE;
         if (oX === 'left' && oY === 'top') {
-            return [-HALF_SIZE, -names[1].split('\n').length * LINE_HEIGHT[oY] - HALF_SIZE];
+            return [-offsetX, -names[1].split('\n').length * LINE_HEIGHT[oY] - offsetY];
         } else if (oX === 'middle' && oY === 'top') {
-            return [0, -names[1].split('\n').length * LINE_HEIGHT[oY] - HALF_SIZE - 2];
+            return [0, -names[1].split('\n').length * LINE_HEIGHT[oY] - offsetY - 2];
         } else if (oX === 'right' && oY === 'top') {
-            return [HALF_SIZE, -names[1].split('\n').length * LINE_HEIGHT[oY] - HALF_SIZE];
+            return [offsetX, -names[1].split('\n').length * LINE_HEIGHT[oY] - offsetY];
         } else if (oX === 'left' && oY === 'bottom') {
-            return [-HALF_SIZE, names[0].split('\n').length * LINE_HEIGHT[oY] + HALF_SIZE];
+            return [-offsetX, names[0].split('\n').length * LINE_HEIGHT[oY] + offsetY];
         } else if (oX === 'middle' && oY === 'bottom') {
-            return [0, names[0].split('\n').length * LINE_HEIGHT[oY] + HALF_SIZE + 2];
+            return [0, names[0].split('\n').length * LINE_HEIGHT[oY] + offsetY + 2];
         } else if (oX === 'right' && oY === 'bottom') {
-            return [HALF_SIZE, names[0].split('\n').length * LINE_HEIGHT[oY] + HALF_SIZE];
+            return [offsetX, names[0].split('\n').length * LINE_HEIGHT[oY] + offsetY];
         } else if (oX === 'left' && oY === 'middle') {
-            return [-HALF_SIZE - 2, 0];
+            return [-offsetM - 2, 0];
         } else if (oX === 'right' && oY === 'middle') {
-            return [HALF_SIZE + 2, 0];
+            return [offsetM + 2, 0];
         } else return [0, 0];
     };
 
-    const [textX, textY] = getTextOffset(nameOffsetX, nameOffsetY);
+    const [textX, textY] = getTextOffset(nameOffsetX, nameOffsetY, textDistance);
     const textAnchor = nameOffsetX === 'left' ? 'end' : nameOffsetX === 'right' ? 'start' : 'middle';
 
     const zhRef = React.useRef<SVGGElement>(null);
@@ -199,9 +203,13 @@ const ChongqingRTIntStation = (props: StationComponentProps) => {
 /**
  * ChongqingRTIntStation specific props.
  */
+
+export type TextDistance = 'near' | 'far';
+
 export interface ChongqingRTIntStationAttributes extends StationAttributes, StationAttributesWithInterchange {
     nameOffsetX: NameOffsetX;
     nameOffsetY: NameOffsetY;
+    textDistance: TextDistance[];
 }
 
 const defaultChongqingRTIntStationAttributes: ChongqingRTIntStationAttributes = {
@@ -215,6 +223,7 @@ const defaultChongqingRTIntStationAttributes: ChongqingRTIntStationAttributes = 
             [CityCode.Chongqing, 'cq6', '#f67599', MonoColour.white, '', ''],
         ],
     ],
+    textDistance: ['near', 'near'],
 };
 
 const ChongqingRTIntAttrsComponent = (props: AttrsProps<ChongqingRTIntStationAttributes>) => {
@@ -266,6 +275,36 @@ const ChongqingRTIntAttrsComponent = (props: AttrsProps<ChongqingRTIntStationAtt
             minW: 'full',
         },
         {
+            type: 'select',
+            label: t('panel.details.stations.chongqingRTInt.textDistance.x'),
+            value: (attrs ?? defaultChongqingRTIntStationAttributes).textDistance[0],
+            options: {
+                far: t('panel.details.stations.chongqingRTInt.textDistance.far'),
+                near: t('panel.details.stations.chongqingRTInt.textDistance.near'),
+            },
+            isDisabled: attrs?.nameOffsetX === 'middle' || attrs?.nameOffsetY === 'middle',
+            onChange: val => {
+                attrs.textDistance[0] = val as TextDistance;
+                handleAttrsUpdate(id, attrs);
+            },
+            minW: 'full',
+        },
+        {
+            type: 'select',
+            label: t('panel.details.stations.chongqingRTInt.textDistance.y'),
+            value: (attrs ?? defaultChongqingRTIntStationAttributes).textDistance[1],
+            options: {
+                far: t('panel.details.stations.chongqingRTInt.textDistance.far'),
+                near: t('panel.details.stations.chongqingRTInt.textDistance.near'),
+            },
+            isDisabled: attrs?.nameOffsetX === 'middle' || attrs?.nameOffsetY === 'middle',
+            onChange: val => {
+                attrs.textDistance[1] = val as TextDistance;
+                handleAttrsUpdate(id, attrs);
+            },
+            minW: 'full',
+        },
+        {
             type: 'custom',
             label: t('panel.details.stations.interchange.title'),
             component: (
@@ -285,7 +324,7 @@ const chongqingRTIntStationIcon = (
         <svg viewBox="0 0 7 7" height={30} width={30} focusable={false}>
             <path
                 style={{
-                    fill: 'none',
+                    fill: 'white',
                     stroke: '#231815',
                     strokeMiterlimit: 22.9,
                     strokeWidth: 0.232,

--- a/src/i18n/translations/en.json
+++ b/src/i18n/translations/en.json
@@ -113,10 +113,10 @@
                     "displayName": "Chongqing Rail Transit text line badge"
                 },
                 "chongqingRTNumLineBadge2021": {
-                    "displayName": "Chongqing Rail Transit num line badge（2021）"
+                    "displayName": "Chongqing Rail Transit num line badge (2021)"
                 },
                 "chongqingRTTextLineBadge2021": {
-                    "displayName": "Chongqing Rail Transit text line badge（2021）",
+                    "displayName": "Chongqing Rail Transit text line badge (2021)",
                     "isRapid": "Is rapid or express train badge"
                 },
                 "shenzhenMetroNumLineBadge": {
@@ -372,7 +372,13 @@
                     "isLoop": "Loop line station"
                 },
                 "chongqingRTInt": {
-                    "displayName": "Chongqing Rail Transit interchange station"
+                    "displayName": "Chongqing Rail Transit interchange station",
+                    "textDistance": {
+                        "x": "Text distance X",
+                        "y": "Text distance Y",
+                        "near": "near",
+                        "far": "far"
+                    } 
                 },
                 "chongqingRTBasic2021": {
                     "displayName": "Chongqing Rail Transit basic station (2021)",

--- a/src/i18n/translations/ja.json
+++ b/src/i18n/translations/ja.json
@@ -372,7 +372,13 @@
                     "isLoop": "環状線駅"
                 },
                 "chongqingRTInt": {
-                    "displayName": "重慶鉄道交通乗り換え駅"
+                    "displayName": "重慶鉄道交通乗り換え駅",
+                    "textDistance": {
+                        "x": "橫文字距離",
+                        "y": "縦文字距離",
+                        "near": "近い",
+                        "far": "遠い"
+                    } 
                 },
                 "chongqingRTBasic2021": {
                     "displayName": "重慶鉄道交通基本駅（令和3年）",

--- a/src/i18n/translations/ko.json
+++ b/src/i18n/translations/ko.json
@@ -113,10 +113,10 @@
                     "displayName": "충칭 철도 교통 텍스트 라인 표시"
                 },
                 "chongqingRTNumLineBadge2021": {
-                    "displayName": "충칭 철도 교통 디지털 노선 식별（2021）"
+                    "displayName": "충칭 철도 교통 디지털 노선 식별 (2021)"
                 },
                 "chongqingRTTextLineBadge2021": {
-                    "displayName": "충칭 철도 교통 텍스트 라인 표시（2021）",
+                    "displayName": "충칭 철도 교통 텍스트 라인 표시 (2021)",
                     "isRapid": "고속 / 직속 열차 식별"
                 },
                 "shenzhenMetroNumLineBadge": {
@@ -371,10 +371,16 @@
                     "isLoop": "순환역"
                 },
                 "chongqingRTInt": {
-                    "displayName": "충칭 궤도교통 환승역"
+                    "displayName": "충칭 궤도교통 환승역",
+                    "textDistance": {
+                        "x": "가로 문자 거리",
+                        "y": "세로 문자 거리",
+                        "near": "가까이",
+                        "far": "멀리"
+                    } 
                 },
                 "chongqingRTBasic2021": {
-                    "displayName": "충칭 궤도교통 기본역（2021）",
+                    "displayName": "충칭 궤도교통 기본역 (2021)",
                     "open": "개통여부"
                 },
                 "chongqingRTInt2021": {

--- a/src/i18n/translations/zh-Hans.json
+++ b/src/i18n/translations/zh-Hans.json
@@ -371,7 +371,13 @@
                     "isLoop": "环线车站"
                 },
                 "chongqingRTInt": {
-                    "displayName": "重庆轨道交通换乘车站"
+                    "displayName": "重庆轨道交通换乘车站",
+                    "textDistance": {
+                        "x": "横向文字距离",
+                        "y": "纵向文字距离",
+                        "near": "近",
+                        "far": "远"
+                    } 
                 },
                 "chongqingRTBasic2021": {
                     "displayName": "重庆轨道交通基本车站（2021）",

--- a/src/i18n/translations/zh-Hant.json
+++ b/src/i18n/translations/zh-Hant.json
@@ -371,7 +371,13 @@
                     "isLoop": "環線車站"
                 },
                 "chongqingRTInt": {
-                    "displayName": "重慶軌道交通換乘車站"
+                    "displayName": "重慶軌道交通換乘車站",
+                    "textDistance": {
+                        "x": "橫向文字距離",
+                        "y": "縱向文字距離",
+                        "near": "近",
+                        "far": "遠"
+                    } 
                 },
                 "chongqingRTBasic2021": {
                     "displayName": "重慶軌道交通基本車站（2021）",

--- a/src/util/save.test.ts
+++ b/src/util/save.test.ts
@@ -598,4 +598,18 @@ describe('Unit tests for param upgrade function', () => {
             '{"svgViewBoxZoom":100,"svgViewBoxMin":{"x":0,"y":0},"graph":{"options":{"type":"directed","multi":true,"allowSelfLoops":true},"attributes":{},"nodes":[{"key":"stn_qO95TqrmPQ","attributes":{"visible":true,"zIndex":0,"x":555,"y":405,"type":"london-tube-basic","london-tube-basic":{"names":["Station"],"transfer":[[["london","central","#DC241F","#fff",0]]],"rotate":0,"terminal":false,"stepFreeAccess":"none","terminalNameRotate":0}}}],"edges":[]},"version":46}';
         expect(newParam).toEqual(expectParam);
     });
+
+    it('46 -> 47', () => {
+        // Bump save version to add textDistance to chongqingrt-int.
+        const oldParam =
+            '{"graph":{"options":{"type":"directed","multi":true,"allowSelfLoops":true},"attributes":{},"nodes":[{"key":"stn_mwvAhFz1r1","attributes":{"visible":true,"zIndex":0,"x":-130,"y":25,"type":"chongqingrt-int","chongqingrt-int":{"names":["大坪","Daping"],"nameOffsetX":"right","nameOffsetY":"top","transfer":[[["chongqing","cq1","#e4002b","#fff","",""],["chongqing","cq2","#007a33","#fff","",""]]]}}}],"edges":[]},"svgViewBoxZoom":100,"svgViewBoxMin":{"x":0,"y":0},"version":46}';
+        // Upgrade it with your newly added function.
+        const newParam = UPGRADE_COLLECTION[46](oldParam);
+        const graph = new MultiDirectedGraph() as MultiDirectedGraph<NodeAttributes, EdgeAttributes, GraphAttributes>;
+        expect(() => graph.import(JSON.parse(newParam))).not.toThrow();
+        const expectParam =
+            '{"graph":{"options":{"type":"directed","multi":true,"allowSelfLoops":true},"attributes":{},"nodes":[{"key":"stn_mwvAhFz1r1","attributes":{"visible":true,"zIndex":0,"x":-130,"y":25,"type":"chongqingrt-int","chongqingrt-int":{"names":["大坪","Daping"],"nameOffsetX":"right","nameOffsetY":"top","transfer":[[["chongqing","cq1","#e4002b","#fff","",""],["chongqing","cq2","#007a33","#fff","",""]]],"textDistance":["near","near"]}}}],"edges":[]},"svgViewBoxZoom":100,"svgViewBoxMin":{"x":0,"y":0},"version":47}';
+        // And the updated save has only version field changed.
+        expect(newParam).toEqual(expectParam);
+    });
 });

--- a/src/util/save.ts
+++ b/src/util/save.ts
@@ -52,7 +52,7 @@ export interface RMPSave {
     svgViewBoxMin: { x: number; y: number };
 }
 
-export const CURRENT_VERSION = 46;
+export const CURRENT_VERSION = 47;
 
 /**
  * Load the tutorial.
@@ -615,5 +615,20 @@ export const UPGRADE_COLLECTION: { [version: number]: (param: string) => string 
                 graph.mergeNodeAttributes(node, { [type]: attr });
             });
         return JSON.stringify({ ...p, version: 46, graph: graph.export() });
+    },
+    46: param => {
+        // Bump save version to add textDistance to chongqingrt-int.
+        const p = JSON.parse(param);
+        const graph = new MultiDirectedGraph() as MultiDirectedGraph<NodeAttributes, EdgeAttributes, GraphAttributes>;
+        graph.import(p?.graph);
+        graph
+            .filterNodes((node, attr) => node.startsWith('stn') && attr.type === StationType.ChongqingRTInt)
+            .forEach(node => {
+                const type = graph.getNodeAttribute(node, 'type');
+                const attr = graph.getNodeAttribute(node, type) as any;
+                attr.textDistance = ['near', 'near'];
+                graph.mergeNodeAttributes(node, { [type]: attr });
+            });
+        return JSON.stringify({ ...p, version: 47, graph: graph.export() });
     },
 };


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/dafa57a2-baff-4421-ae9c-549047294e1f)
![image](https://github.com/user-attachments/assets/f5aa4a1d-4489-43f6-b234-38c6c8bf7708)


添加了文字距离选项以调节平行换乘和十字换乘时的文字间距使换乘站文字更好的对齐于普通站，优化视觉效果。

以及调整了一些翻译和预览图的细节