### PR TITLE
#1212 Fix Osaka Metro Station transfer limit

### DIFF
--- a/src/components/svgs/stations/osaka-metro.tsx
+++ b/src/components/svgs/stations/osaka-metro.tsx
@@ -284,7 +284,7 @@ function calculateTextPosition(config: {
                     (stationDirection === 'vertical' && transferCount > 1
                         ? ((transferCount - 1) * LAYOUT_CONSTANTS.STATION.HEIGHT) / 2 +
                           LAYOUT_CONSTANTS.STATION.STROKE_WIDTH * 2
-                        : 0);
+                        : LAYOUT_CONSTANTS.STATION.STROKE_WIDTH);
             } else if (nameOffsetPosition === 'middle') {
                 textY +=
                     (nameLineCount - 1) * LAYOUT_CONSTANTS.FONT_SIZE.NAME +
@@ -303,7 +303,7 @@ function calculateTextPosition(config: {
                     (stationDirection === 'vertical' && transferCount > 1
                         ? ((transferCount - 1) * LAYOUT_CONSTANTS.STATION.HEIGHT) / 2 +
                           LAYOUT_CONSTANTS.STATION.STROKE_WIDTH * 2
-                        : 0) +
+                        : LAYOUT_CONSTANTS.STATION.STROKE_WIDTH) +
                     LAYOUT_CONSTANTS.MAGIC_OFFSET_9;
             }
         } else if (nameOverallPosition === 'right') {


### PR DESCRIPTION
Original issue: https://github.com/railmapgen/rmp/issues/1212

This fix will:
- Remove the Osaka Metro Station 's limits on permitted transfer lines
- Correct the location of station names on both sides of transfer stations

<img width="1882" height="989" alt="image" src="https://github.com/user-attachments/assets/a72439b6-803e-4e62-94a1-3b5b75be46b2" />
