### PR TITLE
#1347 Prevent browser zoom on touchpad pinch

### DIFF
--- a/src/components/svg-wrapper.tsx
+++ b/src/components/svg-wrapper.tsx
@@ -158,6 +158,24 @@ const SvgWrapper = () => {
             }
         };
     }, []);
+    // prevent browser zoom when ctrl + wheel or cmd + wheel
+    const svgRef = React.useRef<SVGSVGElement>(null);
+
+    React.useEffect(() => {
+        const svgInfo = svgRef.current;
+        if (!svgInfo) return;
+
+        const preventBrowserZoom = (e: WheelEvent) => {
+            if (e.ctrlKey || e.metaKey) {
+                e.preventDefault();
+            }
+        };
+
+        svgInfo.addEventListener('wheel', preventBrowserZoom, { passive: false });
+        return () => {
+            svgInfo.removeEventListener('wheel', preventBrowserZoom);
+        };
+    }, []);
 
     const handleBackgroundDown = useEvent(async (e: React.PointerEvent<SVGSVGElement>) => {
         if (contextMenu.isOpen) {
@@ -269,8 +287,9 @@ const SvgWrapper = () => {
 
     const handleBackgroundWheel = useEvent((e: React.WheelEvent<SVGSVGElement>) => {
         let newSvgViewBoxZoom = svgViewBoxZoom;
-        if (e.deltaY > 0 && svgViewBoxZoom + 10 < 400) newSvgViewBoxZoom = svgViewBoxZoom + 10;
-        else if (e.deltaY < 0 && svgViewBoxZoom - 10 > 0) newSvgViewBoxZoom = svgViewBoxZoom - 10;
+        const zoomStep = e.ctrlKey || e.metaKey ? 5 : 10;
+        if (e.deltaY > 0 && svgViewBoxZoom + zoomStep < 400) newSvgViewBoxZoom = svgViewBoxZoom + zoomStep;
+        else if (e.deltaY < 0 && svgViewBoxZoom - zoomStep > 0) newSvgViewBoxZoom = svgViewBoxZoom - zoomStep;
 
         const { x, y } = getMousePosition(e);
         const bbox = e.currentTarget.getBoundingClientRect();
@@ -449,6 +468,7 @@ const SvgWrapper = () => {
                 height={height}
                 width={width}
                 viewBox={`0 0 ${width} ${height}`}
+                ref={svgRef}
                 onPointerDown={handleBackgroundDown}
                 onPointerMove={handleBackgroundMove}
                 onPointerUp={handleBackgroundUp}


### PR DESCRIPTION
至少在我所使用的设备（Surface Pro 8）的 Chromium 和 Edge 浏览器中，在画布上使用触摸板缩放手势，页面也会跟着一起变大。
这是由于 React 默认将 `onWheel` 注册为被动监听器（Passive Listener，为了滚动性能考虑），导致在 React 的事件回调中直接调用 `e.preventDefault()` 往往无效或者太晚了（Gemini 3 Pro 生成）。
本修改修复了这个问题。
