### PR TITLE
Improve zoom and touchscreen experience by introducing continuous exponential scaling

### DIFF
--- a/src/components/svg-wrapper.tsx
+++ b/src/components/svg-wrapper.tsx
@@ -5,7 +5,16 @@ import { nanoid } from 'nanoid';
 import React from 'react';
 import { MdDoubleArrow } from 'react-icons/md';
 import useEvent from 'react-use-event-hook';
-import { NODES_MOVE_DISTANCE } from '../constants/canvas';
+import {
+    DELTA_LINE_MULTIPLIER,
+    DELTA_PAGE_MULTIPLIER,
+    NODES_MOVE_DISTANCE,
+    TOUCHPAD_SENSITIVITY,
+    WHEEL_SENSITIVITY,
+    ZOOM_BASE,
+    ZOOM_MAX,
+    ZOOM_MIN,
+} from '../constants/canvas';
 import { Events, Id, NodeId, RuntimeMode, StnId } from '../constants/constants';
 import { LinePathType } from '../constants/lines';
 import { MAX_MASTER_NODE_FREE } from '../constants/master';
@@ -102,6 +111,13 @@ const SvgWrapper = () => {
     // background dragging related
     const dragStartRef = React.useRef({ x: 0, y: 0 });
     const initialViewBoxMinRef = React.useRef({ x: 0, y: 0 });
+    // live refs keep zoom/min in sync with the latest dispatch so that consecutive
+    // wheel/pinch events within the same React batch read up-to-date values instead
+    // of the stale Redux snapshot captured at the start of the render.
+    const liveZoomRef = React.useRef(svgViewBoxZoom);
+    const liveMinRef = React.useRef(svgViewBoxMin);
+    liveZoomRef.current = svgViewBoxZoom;
+    liveMinRef.current = svgViewBoxMin;
 
     // helper function to calculate the new svgViewBoxMin based on the current
     // mouse position and the initial position when dragging starts
@@ -286,19 +302,33 @@ const SvgWrapper = () => {
     });
 
     const handleBackgroundWheel = useEvent((e: React.WheelEvent<SVGSVGElement>) => {
-        let newSvgViewBoxZoom = svgViewBoxZoom;
-        const zoomStep = e.ctrlKey || e.metaKey ? 5 : 10;
-        if (e.deltaY > 0 && svgViewBoxZoom + zoomStep < 400) newSvgViewBoxZoom = svgViewBoxZoom + zoomStep;
-        else if (e.deltaY < 0 && svgViewBoxZoom - zoomStep > 0) newSvgViewBoxZoom = svgViewBoxZoom - zoomStep;
+        // normalize deltaY: DOM_DELTA_PIXEL (0) needs no conversion,
+        // DOM_DELTA_LINE (1, Firefox mouse) and DOM_DELTA_PAGE (2, rare) are scaled
+        // to approximate pixel equivalents.
+        let delta = e.deltaY;
+        if (e.deltaMode === 1) delta *= DELTA_LINE_MULTIPLIER;
+        else if (e.deltaMode === 2) delta *= DELTA_PAGE_MULTIPLIER;
+
+        // touchpad pinch fires as ctrlKey + wheel with small deltaY, use lower divisor
+        const sensitivity = e.ctrlKey || e.metaKey ? TOUCHPAD_SENSITIVITY : WHEEL_SENSITIVITY;
+
+        const currentZoom = liveZoomRef.current;
+        const currentMin = liveMinRef.current;
+
+        const factor = Math.pow(ZOOM_BASE, delta / sensitivity);
+        const newSvgViewBoxZoom = Math.min(ZOOM_MAX, Math.max(ZOOM_MIN, currentZoom * factor));
 
         const { x, y } = getMousePosition(e);
         const bbox = e.currentTarget.getBoundingClientRect();
         const [x_factor, y_factor] = [x / bbox.width, y / bbox.height];
 
         const newMin = {
-            x: svgViewBoxMin.x + (x * svgViewBoxZoom) / 100 - ((width * newSvgViewBoxZoom) / 100) * x_factor,
-            y: svgViewBoxMin.y + (y * svgViewBoxZoom) / 100 - ((height * newSvgViewBoxZoom) / 100) * y_factor,
+            x: currentMin.x + (x * currentZoom) / 100 - ((width * newSvgViewBoxZoom) / 100) * x_factor,
+            y: currentMin.y + (y * currentZoom) / 100 - ((height * newSvgViewBoxZoom) / 100) * y_factor,
         };
+
+        liveZoomRef.current = newSvgViewBoxZoom;
+        liveMinRef.current = newMin;
 
         dispatch(setSvgViewBoxZoom(newSvgViewBoxZoom));
         dispatch(setSvgViewBoxMin(newMin));

--- a/src/components/svg-wrapper.tsx
+++ b/src/components/svg-wrapper.tsx
@@ -9,6 +9,7 @@ import {
     DELTA_LINE_MULTIPLIER,
     DELTA_PAGE_MULTIPLIER,
     NODES_MOVE_DISTANCE,
+    TOUCH_PLACE_DEFER_MS,
     TOUCHPAD_SENSITIVITY,
     WHEEL_SENSITIVITY,
     ZOOM_BASE,
@@ -118,6 +119,12 @@ const SvgWrapper = () => {
     const liveMinRef = React.useRef(svgViewBoxMin);
     liveZoomRef.current = svgViewBoxZoom;
     liveMinRef.current = svgViewBoxMin;
+    // defer touch node placement so a second finger (pinch) can cancel it
+    const touchDeferTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+    const pointerCountRef = React.useRef(0);
+    // tracks the latest drag-computed viewBoxMin so that multi-touch cancellation
+    // can commit the current visual position instead of reverting to Redux state.
+    const lastDragViewBoxMinRef = React.useRef(svgViewBoxMin);
 
     // helper function to calculate the new svgViewBoxMin based on the current
     // mouse position and the initial position when dragging starts
@@ -165,12 +172,16 @@ const SvgWrapper = () => {
     // instead of dispatching Redux action which will cause re-render on every pointer move.
     const rafRef = React.useRef<number | null>(null);
 
-    // cleanup RAF on unmount to prevent calling updateViewportTransform after unmount
+    // cleanup RAF and touch defer timer on unmount
     React.useEffect(() => {
         return () => {
             if (rafRef.current) {
                 cancelAnimationFrame(rafRef.current);
                 rafRef.current = null;
+            }
+            if (touchDeferTimerRef.current) {
+                clearTimeout(touchDeferTimerRef.current);
+                touchDeferTimerRef.current = null;
             }
         };
     }, []);
@@ -194,6 +205,28 @@ const SvgWrapper = () => {
     }, []);
 
     const handleBackgroundDown = useEvent(async (e: React.PointerEvent<SVGSVGElement>) => {
+        const isTouch = e.pointerType === 'touch';
+        pointerCountRef.current++;
+
+        // multi-touch: cancel pending deferred actions and stop background drag
+        // pinch-to-zoom is handled by touch-overlay
+        if (isTouch && pointerCountRef.current >= 2) {
+            if (touchDeferTimerRef.current) {
+                clearTimeout(touchDeferTimerRef.current);
+                touchDeferTimerRef.current = null;
+            }
+            if (active === 'background') {
+                if (rafRef.current) {
+                    cancelAnimationFrame(rafRef.current);
+                    rafRef.current = null;
+                }
+                // commit the position the user dragged to, not the pre-drag Redux value
+                dispatch(setSvgViewBoxMin(lastDragViewBoxMinRef.current));
+                dispatch(setActive(undefined));
+            }
+            return;
+        }
+
         if (contextMenu.isOpen) {
             // close context menu if it's open
             setContextMenu({ isOpen: false, position: { x: 0, y: 0 } });
@@ -201,33 +234,43 @@ const SvgWrapper = () => {
 
         const { x, y } = getMousePosition(e);
         if (mode.startsWith('station') || mode.startsWith('misc-node')) {
-            dispatch(setMode('free'));
-            const rand = nanoid(10);
-            const { x: svgX, y: svgY } = pointerPosToSVGCoord(x, y, svgViewBoxZoom, svgViewBoxMin);
+            const doPlaceNode = async () => {
+                dispatch(setMode('free'));
+                const rand = nanoid(10);
+                const { x: svgX, y: svgY } = pointerPosToSVGCoord(x, y, svgViewBoxZoom, svgViewBoxMin);
 
-            const isStation = mode.startsWith('station');
-            const id: NodeId = isStation ? `stn_${rand}` : `misc_node_${rand}`;
-            const type = (isStation ? mode.slice(8) : mode.slice(10)) as StationType | MiscNodeType;
+                const isStation = mode.startsWith('station');
+                const id: NodeId = isStation ? `stn_${rand}` : `misc_node_${rand}`;
+                const type = (isStation ? mode.slice(8) : mode.slice(10)) as StationType | MiscNodeType;
 
-            // deep copy to prevent mutual reference
-            const attr = structuredClone({ ...stations, ...miscNodes }[type].defaultAttrs);
-            // inject runtime color if registered in dynamicColorInjection
-            if (dynamicColorInjection.has(type)) (attr as AttributesWithColor).color = theme;
-            // Add random names for stations
-            if (isStation) (attr as StationAttributes).names = await makeStationName(type as StationType);
+                // deep copy to prevent mutual reference
+                const attr = structuredClone({ ...stations, ...miscNodes }[type].defaultAttrs);
+                // inject runtime color if registered in dynamicColorInjection
+                if (dynamicColorInjection.has(type)) (attr as AttributesWithColor).color = theme;
+                // Add random names for stations
+                if (isStation) (attr as StationAttributes).names = await makeStationName(type as StationType);
 
-            graph.current.addNode(id, {
-                visible: true,
-                zIndex: 0,
-                x: roundToMultiple(svgX, 5),
-                y: roundToMultiple(svgY, 5),
-                type,
-                [type]: attr,
-            });
-            // console.log('down', active, offset);
-            if (isAllowProjectTelemetry) rmgRuntime.event(Events.ADD_STATION, { type });
-            refreshAndSave();
-            dispatch(setSelected(new Set([id])));
+                graph.current.addNode(id, {
+                    visible: true,
+                    zIndex: 0,
+                    x: roundToMultiple(svgX, 5),
+                    y: roundToMultiple(svgY, 5),
+                    type,
+                    [type]: attr,
+                });
+                if (isAllowProjectTelemetry) rmgRuntime.event(Events.ADD_STATION, { type });
+                refreshAndSave();
+                dispatch(setSelected(new Set([id])));
+            };
+
+            if (isTouch) {
+                touchDeferTimerRef.current = setTimeout(() => {
+                    touchDeferTimerRef.current = null;
+                    doPlaceNode();
+                }, TOUCH_PLACE_DEFER_MS);
+            } else {
+                await doPlaceNode();
+            }
         } else if (mode === 'free' || mode.startsWith('line')) {
             // deselect line tool if user clicks on the background
             if (mode.startsWith('line')) {
@@ -257,12 +300,15 @@ const SvgWrapper = () => {
                 setSelectMoving(pointerPosToSVGCoord(x, y, svgViewBoxZoom, svgViewBoxMin));
             }
         } else if (active === 'background') {
+            // skip drag when multi-touch is active (pinch handled by touch-overlay)
+            if (pointerCountRef.current >= 2) return;
             const { x, y } = getMousePosition(e);
             if (!rafRef.current) {
                 // Use requestAnimationFrame to throttle the updates to at most
                 // once per frame for better performance during dragging.
                 rafRef.current = requestAnimationFrame(() => {
                     const tempSVGViewBoxMin = makeSVGViewBoxMin(x, y);
+                    lastDragViewBoxMinRef.current = tempSVGViewBoxMin;
                     updateViewportTransform(tempSVGViewBoxMin, svgViewBoxZoom);
                     rafRef.current = null;
                 });
@@ -270,6 +316,7 @@ const SvgWrapper = () => {
         }
     });
     const handleBackgroundUp = useEvent((e: React.PointerEvent<SVGSVGElement>) => {
+        pointerCountRef.current = Math.max(0, pointerCountRef.current - 1);
         const { x, y } = getMousePosition(e);
         if (mode === 'select') {
             const { x: svgX, y: svgY } = pointerPosToSVGCoord(x, y, svgViewBoxZoom, svgViewBoxMin);

--- a/src/components/svg-wrapper.tsx
+++ b/src/components/svg-wrapper.tsx
@@ -228,6 +228,13 @@ const SvgWrapper = () => {
             return;
         }
 
+        // when a node is already being interacted with (e.g. dragging a station),
+        // ignore additional touch on the background to prevent overwriting active
+        // and causing canvas drift. the user must lift all fingers first.
+        if (isTouch && active && active !== 'background') {
+            return;
+        }
+
         if (contextMenu.isOpen) {
             // close context menu if it's open
             setContextMenu({ isOpen: false, position: { x: 0, y: 0 } });

--- a/src/components/svg-wrapper.tsx
+++ b/src/components/svg-wrapper.tsx
@@ -158,6 +158,24 @@ const SvgWrapper = () => {
             }
         };
     }, []);
+    // prevent browser zoom when ctrl + wheel or cmd + wheel
+    const svgRef = React.useRef<SVGSVGElement>(null);
+
+    React.useEffect(() => {
+        const svgInfo = svgRef.current;
+        if (!svgInfo) return;
+
+        const preventBrowserZoom = (e: WheelEvent) => {
+            if (e.ctrlKey || e.metaKey) {
+                e.preventDefault();
+            }
+        };
+
+        svgInfo.addEventListener('wheel', preventBrowserZoom, { passive: false });
+        return () => {
+            svgInfo.removeEventListener('wheel', preventBrowserZoom);
+        };
+    }, []);
 
     const handleBackgroundDown = useEvent(async (e: React.PointerEvent<SVGSVGElement>) => {
         if (contextMenu.isOpen) {
@@ -269,8 +287,9 @@ const SvgWrapper = () => {
 
     const handleBackgroundWheel = useEvent((e: React.WheelEvent<SVGSVGElement>) => {
         let newSvgViewBoxZoom = svgViewBoxZoom;
-        if (e.deltaY > 0 && svgViewBoxZoom + 10 < 400) newSvgViewBoxZoom = svgViewBoxZoom + 10;
-        else if (e.deltaY < 0 && svgViewBoxZoom - 10 > 0) newSvgViewBoxZoom = svgViewBoxZoom - 10;
+        const zoomStep = e.ctrlKey || e.metaKey ? 5 : 10;
+        if (e.deltaY > 0 && svgViewBoxZoom + zoomStep < 400) newSvgViewBoxZoom = svgViewBoxZoom + zoomStep;
+        else if (e.deltaY < 0 && svgViewBoxZoom - zoomStep > 0) newSvgViewBoxZoom = svgViewBoxZoom - zoomStep;
 
         const { x, y } = getMousePosition(e);
         const bbox = e.currentTarget.getBoundingClientRect();
@@ -449,6 +468,7 @@ const SvgWrapper = () => {
                 height={height}
                 width={width}
                 viewBox={`0 0 ${width} ${height}`}
+                ref={svgRef}
                 onPointerDown={handleBackgroundDown}
                 onPointerMove={handleBackgroundMove}
                 onPointerUp={handleBackgroundUp}

--- a/src/components/svg-wrapper.tsx
+++ b/src/components/svg-wrapper.tsx
@@ -283,6 +283,7 @@ const SvgWrapper = () => {
             // set initial position of the pointer, this is used in handleBackgroundMove
             dragStartRef.current = { x, y };
             initialViewBoxMinRef.current = svgViewBoxMin;
+            lastDragViewBoxMinRef.current = svgViewBoxMin;
             if (!e.shiftKey) {
                 // when user holding the shift key and mis-click the background
                 // preserve the current selection
@@ -326,6 +327,7 @@ const SvgWrapper = () => {
             const { x, y } = getMousePosition(e);
             dragStartRef.current = { x, y };
             initialViewBoxMinRef.current = svgViewBoxMin;
+            lastDragViewBoxMinRef.current = svgViewBoxMin;
             dispatch(setActive('background'));
         }
     });

--- a/src/components/svg-wrapper.tsx
+++ b/src/components/svg-wrapper.tsx
@@ -13,6 +13,7 @@ import {
     TOUCHPAD_SENSITIVITY,
     WHEEL_SENSITIVITY,
     ZOOM_BASE,
+    ZOOM_DAMPING_RANGE,
     ZOOM_MAX,
     ZOOM_MIN,
 } from '../constants/canvas';
@@ -313,6 +314,19 @@ const SvgWrapper = () => {
                     rafRef.current = null;
                 });
             }
+        } else if (
+            e.pointerType === 'touch' &&
+            pointerCountRef.current === 1 &&
+            active === undefined &&
+            (mode === 'free' || mode.startsWith('line'))
+        ) {
+            // re-initiate drag after multi-touch (pinch) ends with one finger remaining.
+            // setActive dispatches are batched by React so multiple pointermove events may
+            // arrive before the next render — the active === undefined guard prevents duplicates.
+            const { x, y } = getMousePosition(e);
+            dragStartRef.current = { x, y };
+            initialViewBoxMinRef.current = svgViewBoxMin;
+            dispatch(setActive('background'));
         }
     });
     const handleBackgroundUp = useEvent((e: React.PointerEvent<SVGSVGElement>) => {
@@ -362,7 +376,17 @@ const SvgWrapper = () => {
         const currentZoom = liveZoomRef.current;
         const currentMin = liveMinRef.current;
 
-        const factor = Math.pow(ZOOM_BASE, delta / sensitivity);
+        let factor = Math.pow(ZOOM_BASE, delta / sensitivity);
+        // dampen the factor near ZOOM_MIN / ZOOM_MAX so the user feels deceleration
+        // instead of an abrupt stop at the boundary
+        const raw = currentZoom * factor;
+        if (raw < ZOOM_MIN + ZOOM_DAMPING_RANGE && factor < 1) {
+            const t = Math.max(0, (currentZoom - ZOOM_MIN) / ZOOM_DAMPING_RANGE);
+            factor = 1 + (factor - 1) * t;
+        } else if (raw > ZOOM_MAX - ZOOM_DAMPING_RANGE && factor > 1) {
+            const t = Math.max(0, (ZOOM_MAX - currentZoom) / ZOOM_DAMPING_RANGE);
+            factor = 1 + (factor - 1) * t;
+        }
         const newSvgViewBoxZoom = Math.min(ZOOM_MAX, Math.max(ZOOM_MIN, currentZoom * factor));
 
         const { x, y } = getMousePosition(e);

--- a/src/components/touch/touch-overlay.tsx
+++ b/src/components/touch/touch-overlay.tsx
@@ -4,7 +4,7 @@ import { useRootDispatch, useRootSelector } from '../../redux';
 import { setSvgViewBoxMin, setSvgViewBoxZoom } from '../../redux/param/param-slice';
 import { clearSelected, closeRadialTouchMenu, setActive, setRadialTouchMenu } from '../../redux/runtime/runtime-slice';
 import { MenuCategory, findNearbyElements } from '../../util/graph-nearby-elements';
-import { ZOOM_MAX, ZOOM_MIN } from '../../constants/canvas';
+import { TOUCH_RADIAL_DEFER_MS, ZOOM_MAX, ZOOM_MIN } from '../../constants/canvas';
 import { getCanvasSize, pointerPosToSVGCoord } from '../../util/helpers';
 import { useWindowSize } from '../../util/hooks';
 
@@ -29,11 +29,19 @@ export const TouchOverlay: React.FC = () => {
     liveZoomRef.current = svgViewBoxZoom;
     liveMinRef.current = svgViewBoxMin;
 
+    // delay single-finger logic so a quick second finger (pinch) can cancel it
+    const singleTouchTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+
     const size = useWindowSize();
     const { height, width } = getCanvasSize(size);
 
     const handleTouchStart = useEvent((e: React.TouchEvent<SVGRectElement>) => {
         if (e.touches.length >= 2) {
+            // cancel any pending single-touch work
+            if (singleTouchTimerRef.current) {
+                clearTimeout(singleTouchTimerRef.current);
+                singleTouchTimerRef.current = null;
+            }
             // multi-touch for zoom
             dispatch(setActive(undefined));
             const [dx, dy] = [e.touches[0].clientX - e.touches[1].clientX, e.touches[0].clientY - e.touches[1].clientY];
@@ -46,31 +54,37 @@ export const TouchOverlay: React.FC = () => {
                 return;
             }
 
+            // defer expensive single-finger logic so pinch gestures skip it entirely
             const touch = e.touches[0];
-            const bbox = document.getElementById('canvas')?.getBoundingClientRect();
-            if (!bbox) return;
-            const relativeX = touch.clientX - bbox.left;
-            const relativeY = touch.clientY - bbox.top;
-            const svgCoord = pointerPosToSVGCoord(relativeX, relativeY, svgViewBoxZoom, svgViewBoxMin);
-            const nearbyElements = findNearbyElements(graph.current, svgCoord, dispatch);
-            if (
-                [
-                    ...nearbyElements[MenuCategory.STATION],
-                    ...nearbyElements[MenuCategory.MISC_NODE],
-                    ...nearbyElements[MenuCategory.LINE],
-                ].length > 0
-            ) {
-                dispatch(
-                    setRadialTouchMenu({
-                        visible: true,
-                        position: svgCoord,
-                        data: nearbyElements,
-                    })
-                );
-            } else {
-                dispatch(clearSelected());
-                dispatch(closeRadialTouchMenu());
-            }
+            const clientX = touch.clientX;
+            const clientY = touch.clientY;
+            singleTouchTimerRef.current = setTimeout(() => {
+                singleTouchTimerRef.current = null;
+                const bbox = document.getElementById('canvas')?.getBoundingClientRect();
+                if (!bbox) return;
+                const relativeX = clientX - bbox.left;
+                const relativeY = clientY - bbox.top;
+                const svgCoord = pointerPosToSVGCoord(relativeX, relativeY, svgViewBoxZoom, svgViewBoxMin);
+                const nearbyElements = findNearbyElements(graph.current, svgCoord, dispatch);
+                if (
+                    [
+                        ...nearbyElements[MenuCategory.STATION],
+                        ...nearbyElements[MenuCategory.MISC_NODE],
+                        ...nearbyElements[MenuCategory.LINE],
+                    ].length > 0
+                ) {
+                    dispatch(
+                        setRadialTouchMenu({
+                            visible: true,
+                            position: svgCoord,
+                            data: nearbyElements,
+                        })
+                    );
+                } else {
+                    dispatch(clearSelected());
+                    dispatch(closeRadialTouchMenu());
+                }
+            }, TOUCH_RADIAL_DEFER_MS);
         }
     });
 
@@ -108,9 +122,25 @@ export const TouchOverlay: React.FC = () => {
     });
 
     const handleTouchEnd = useEvent((e: React.TouchEvent<SVGRectElement>) => {
+        // cancel single-touch timer only when all fingers are lifted.
+        // during a pinch the timer is already cleared in handleTouchStart,
+        // so this guard is a belt-and-suspenders safety net.
+        if (e.touches.length === 0 && singleTouchTimerRef.current) {
+            clearTimeout(singleTouchTimerRef.current);
+            singleTouchTimerRef.current = null;
+        }
         // reset pinch state
         touchDistRef.current = 0;
     });
+
+    // cleanup timer on unmount
+    React.useEffect(() => {
+        return () => {
+            if (singleTouchTimerRef.current) {
+                clearTimeout(singleTouchTimerRef.current);
+            }
+        };
+    }, []);
 
     return (
         <rect

--- a/src/components/touch/touch-overlay.tsx
+++ b/src/components/touch/touch-overlay.tsx
@@ -4,7 +4,7 @@ import { useRootDispatch, useRootSelector } from '../../redux';
 import { setSvgViewBoxMin, setSvgViewBoxZoom } from '../../redux/param/param-slice';
 import { clearSelected, closeRadialTouchMenu, setActive, setRadialTouchMenu } from '../../redux/runtime/runtime-slice';
 import { MenuCategory, findNearbyElements } from '../../util/graph-nearby-elements';
-import { TOUCH_RADIAL_DEFER_MS, ZOOM_MAX, ZOOM_MIN } from '../../constants/canvas';
+import { TOUCH_RADIAL_DEFER_MS, ZOOM_DAMPING_RANGE, ZOOM_MAX, ZOOM_MIN } from '../../constants/canvas';
 import { getCanvasSize, pointerPosToSVGCoord } from '../../util/helpers';
 import { useWindowSize } from '../../util/hooks';
 
@@ -89,6 +89,11 @@ export const TouchOverlay: React.FC = () => {
     });
 
     const handleTouchMove = useEvent((e: React.TouchEvent<SVGRectElement>) => {
+        // safety: cancel single-touch timer if somehow still pending during multi-touch
+        if (e.touches.length >= 2 && singleTouchTimerRef.current) {
+            clearTimeout(singleTouchTimerRef.current);
+            singleTouchTimerRef.current = null;
+        }
         if (e.touches.length === 2 && touchDistRef.current > 0) {
             const [dx, dy] = [e.touches[0].clientX - e.touches[1].clientX, e.touches[0].clientY - e.touches[1].clientY];
             const d = dx * dx + dy * dy;
@@ -97,7 +102,16 @@ export const TouchOverlay: React.FC = () => {
             const currentMin = liveMinRef.current;
 
             // continuous multiplicative zoom based on pinch distance ratio
-            const ratio = Math.sqrt(d / touchDistRef.current);
+            let ratio = Math.sqrt(d / touchDistRef.current);
+            // dampen near ZOOM_MIN / ZOOM_MAX so the user feels deceleration
+            const rawPinch = currentZoom / ratio;
+            if (rawPinch < ZOOM_MIN + ZOOM_DAMPING_RANGE && ratio > 1) {
+                const t = Math.max(0, (currentZoom - ZOOM_MIN) / ZOOM_DAMPING_RANGE);
+                ratio = 1 + (ratio - 1) * t;
+            } else if (rawPinch > ZOOM_MAX - ZOOM_DAMPING_RANGE && ratio < 1) {
+                const t = Math.max(0, (ZOOM_MAX - currentZoom) / ZOOM_DAMPING_RANGE);
+                ratio = 1 + (ratio - 1) * t;
+            }
             const newSvgViewBoxZoom = Math.min(ZOOM_MAX, Math.max(ZOOM_MIN, currentZoom / ratio));
 
             // the mid-position the fingers touch will still be in the same place after zooming
@@ -129,7 +143,7 @@ export const TouchOverlay: React.FC = () => {
             clearTimeout(singleTouchTimerRef.current);
             singleTouchTimerRef.current = null;
         }
-        // reset pinch state
+        // reset pinch state so one remaining finger doesn't continue zooming
         touchDistRef.current = 0;
     });
 

--- a/src/components/touch/touch-overlay.tsx
+++ b/src/components/touch/touch-overlay.tsx
@@ -4,6 +4,7 @@ import { useRootDispatch, useRootSelector } from '../../redux';
 import { setSvgViewBoxMin, setSvgViewBoxZoom } from '../../redux/param/param-slice';
 import { clearSelected, closeRadialTouchMenu, setActive, setRadialTouchMenu } from '../../redux/runtime/runtime-slice';
 import { MenuCategory, findNearbyElements } from '../../util/graph-nearby-elements';
+import { ZOOM_MAX, ZOOM_MIN } from '../../constants/canvas';
 import { getCanvasSize, pointerPosToSVGCoord } from '../../util/helpers';
 import { useWindowSize } from '../../util/hooks';
 
@@ -19,19 +20,28 @@ export const TouchOverlay: React.FC = () => {
     const { radialTouchMenu } = useRootSelector(state => state.runtime);
     const graph = React.useRef(window.graph);
 
-    // Touch state variables for handling mobile gestures:
-    // touchDist: tracks the distance between two fingers for pinch-to-zoom (0 when not zooming)
-    const [touchDist, setTouchDist] = React.useState(0);
+    // live refs keep zoom/min in sync with the latest dispatch so that consecutive
+    // pinch events within the same React batch read up-to-date values instead of
+    // the stale Redux snapshot captured at the start of the render.
+    const touchDistRef = React.useRef(0);
+    const liveZoomRef = React.useRef(svgViewBoxZoom);
+    const liveMinRef = React.useRef(svgViewBoxMin);
+    liveZoomRef.current = svgViewBoxZoom;
+    liveMinRef.current = svgViewBoxMin;
 
     const size = useWindowSize();
     const { height, width } = getCanvasSize(size);
 
     const handleTouchStart = useEvent((e: React.TouchEvent<SVGRectElement>) => {
-        if (e.touches.length == 1) {
-            setTouchDist(0);
+        if (e.touches.length >= 2) {
+            // multi-touch for zoom
+            dispatch(setActive(undefined));
+            const [dx, dy] = [e.touches[0].clientX - e.touches[1].clientX, e.touches[0].clientY - e.touches[1].clientY];
+            touchDistRef.current = dx * dx + dy * dy;
+        } else if (e.touches.length === 1) {
+            touchDistRef.current = 0;
 
             if (radialTouchMenu.visible) {
-                // If menu is already open, close it on this touch
                 dispatch(closeRadialTouchMenu());
                 return;
             }
@@ -61,24 +71,20 @@ export const TouchOverlay: React.FC = () => {
                 dispatch(clearSelected());
                 dispatch(closeRadialTouchMenu());
             }
-        } else if (e.touches.length == 2) {
-            // Multi-touch for zoom
-            dispatch(setActive(undefined));
-            const [dx, dy] = [e.touches[0].clientX - e.touches[1].clientX, e.touches[0].clientY - e.touches[1].clientY];
-            setTouchDist(dx * dx + dy * dy);
         }
     });
 
     const handleTouchMove = useEvent((e: React.TouchEvent<SVGRectElement>) => {
-        if (e.touches.length == 2 && touchDist > 0) {
+        if (e.touches.length === 2 && touchDistRef.current > 0) {
             const [dx, dy] = [e.touches[0].clientX - e.touches[1].clientX, e.touches[0].clientY - e.touches[1].clientY];
             const d = dx * dx + dy * dy;
 
-            let newSvgViewBoxZoom = svgViewBoxZoom;
-            if (d - touchDist < 0 && svgViewBoxZoom + 10 <= 390) newSvgViewBoxZoom = svgViewBoxZoom + 10;
-            else if (d - touchDist > 0 && svgViewBoxZoom - 10 >= 10) newSvgViewBoxZoom = svgViewBoxZoom - 10;
-            dispatch(setSvgViewBoxZoom(newSvgViewBoxZoom));
-            setTouchDist(d);
+            const currentZoom = liveZoomRef.current;
+            const currentMin = liveMinRef.current;
+
+            // continuous multiplicative zoom based on pinch distance ratio
+            const ratio = Math.sqrt(d / touchDistRef.current);
+            const newSvgViewBoxZoom = Math.min(ZOOM_MAX, Math.max(ZOOM_MIN, currentZoom / ratio));
 
             // the mid-position the fingers touch will still be in the same place after zooming
             const bbox = e.currentTarget.getBoundingClientRect();
@@ -87,18 +93,23 @@ export const TouchOverlay: React.FC = () => {
                 (e.touches[0].clientY + e.touches[1].clientY) / 2 - bbox.top,
             ];
             const [x_factor, y_factor] = [x / bbox.width, y / bbox.height];
-            dispatch(
-                setSvgViewBoxMin({
-                    x: svgViewBoxMin.x + (x * svgViewBoxZoom) / 100 - ((width * newSvgViewBoxZoom) / 100) * x_factor,
-                    y: svgViewBoxMin.y + (y * svgViewBoxZoom) / 100 - ((height * newSvgViewBoxZoom) / 100) * y_factor,
-                })
-            );
+            const newMin = {
+                x: currentMin.x + (x * currentZoom) / 100 - ((width * newSvgViewBoxZoom) / 100) * x_factor,
+                y: currentMin.y + (y * currentZoom) / 100 - ((height * newSvgViewBoxZoom) / 100) * y_factor,
+            };
+
+            liveZoomRef.current = newSvgViewBoxZoom;
+            liveMinRef.current = newMin;
+            touchDistRef.current = d;
+
+            dispatch(setSvgViewBoxZoom(newSvgViewBoxZoom));
+            dispatch(setSvgViewBoxMin(newMin));
         }
     });
 
     const handleTouchEnd = useEvent((e: React.TouchEvent<SVGRectElement>) => {
-        // Reset panning state
-        setTouchDist(0);
+        // reset pinch state
+        touchDistRef.current = 0;
     });
 
     return (

--- a/src/components/touch/touch-overlay.tsx
+++ b/src/components/touch/touch-overlay.tsx
@@ -17,7 +17,7 @@ import { useWindowSize } from '../../util/hooks';
 export const TouchOverlay: React.FC = () => {
     const dispatch = useRootDispatch();
     const { svgViewBoxZoom, svgViewBoxMin } = useRootSelector(state => state.param);
-    const { radialTouchMenu } = useRootSelector(state => state.runtime);
+    const { radialTouchMenu, active } = useRootSelector(state => state.runtime);
     const graph = React.useRef(window.graph);
 
     // live refs keep zoom/min in sync with the latest dispatch so that consecutive
@@ -42,8 +42,11 @@ export const TouchOverlay: React.FC = () => {
                 clearTimeout(singleTouchTimerRef.current);
                 singleTouchTimerRef.current = null;
             }
-            // multi-touch for zoom
-            dispatch(setActive(undefined));
+            // multi-touch for zoom — only clear active for background drags,
+            // not when a node is being interacted with (pointer captured by node)
+            if (!active || active === 'background') {
+                dispatch(setActive(undefined));
+            }
             const [dx, dy] = [e.touches[0].clientX - e.touches[1].clientX, e.touches[0].clientY - e.touches[1].clientY];
             touchDistRef.current = dx * dx + dy * dy;
         } else if (e.touches.length === 1) {

--- a/src/constants/canvas.ts
+++ b/src/constants/canvas.ts
@@ -17,6 +17,14 @@ export const TOUCHPAD_SENSITIVITY = 20;
 export const DELTA_LINE_MULTIPLIER = 40;
 export const DELTA_PAGE_MULTIPLIER = 100;
 
+// touch defer timings (ms)
+// node placement: delay so a second finger for pinch can cancel a destructive
+//   action (adding a node). shorter delays risk accidental placement.
+// radial menu detection: shorter delay because nearby-element lookup is
+//   non-destructive and the menu can be easily dismissed.
+export const TOUCH_PLACE_DEFER_MS = 150;
+export const TOUCH_RADIAL_DEFER_MS = 80;
+
 /**
  * Structure for guide lines when dragging / moving the nodes.
  */

--- a/src/constants/canvas.ts
+++ b/src/constants/canvas.ts
@@ -3,6 +3,20 @@ import { NodeId } from './constants';
 // Number of distance to move when moving nodes.
 export const NODES_MOVE_DISTANCE = 5;
 
+// zoom constants for wheel and pinch
+export const ZOOM_BASE = 1.2;
+export const ZOOM_MIN = 10;
+export const ZOOM_MAX = 400;
+export const WHEEL_SENSITIVITY = 150;
+export const TOUCHPAD_SENSITIVITY = 20;
+
+// deltaMode multipliers (WheelEvent.DOM_DELTA_LINE / DOM_DELTA_PAGE)
+// line mode: Firefox reports ~3 lines per tick; CSS spec suggests 1 line ≈ 40px,
+//   so 3 × 40 = 120 which is comparable to Chrome's pixel-mode ~100.
+// page mode: rare, approximate a page as ~100px for a reasonable zoom step.
+export const DELTA_LINE_MULTIPLIER = 40;
+export const DELTA_PAGE_MULTIPLIER = 100;
+
 /**
  * Structure for guide lines when dragging / moving the nodes.
  */

--- a/src/constants/canvas.ts
+++ b/src/constants/canvas.ts
@@ -17,6 +17,10 @@ export const TOUCHPAD_SENSITIVITY = 20;
 export const DELTA_LINE_MULTIPLIER = 40;
 export const DELTA_PAGE_MULTIPLIER = 100;
 
+// soft-clamp margin: within this range of ZOOM_MIN / ZOOM_MAX the zoom factor
+// is progressively damped so the user feels deceleration instead of an abrupt stop.
+export const ZOOM_DAMPING_RANGE = 30;
+
 // touch defer timings (ms)
 // node placement: delay so a second finger for pinch can cancel a destructive
 //   action (adding a node). shorter delays risk accidental placement.


### PR DESCRIPTION
## 描述

基于 `fix/touchpad-zoom`（阻止浏览器默认缩放），将画布缩放体验从固定步进升级为连续指数缩放，以获得和其他常用软件类似的缩放体验，并修复触屏设备上的多指手势冲突问题。

目标是让鼠标滚轮、触控板捏合、手机双指捏合三种输入方式都获得丝滑、一致的缩放手感，同时消除触屏上误放置车站、视口闪回等 UX 问题。

## 主要更改

### 1. 连续指数缩放 (`5786ba12`)
- 将缩放从固定 ±10 步进改为 `currentZoom × ZOOM_BASE^(delta / sensitivity)` 的连续乘法公式，在任意缩放级别下手感一致
- 触控板捏合（`ctrlKey`）与鼠标滚轮使用不同灵敏度参数，适配两种设备的 deltaY 量级差异
- 适配 Firefox 的 `DOM_DELTA_LINE` / `DOM_DELTA_PAGE` deltaMode，统一为像素等价值
- 引入 `liveZoomRef` / `liveMinRef`，在同一帧内多次触发的滚轮事件之间保持缩放值同步，避免 React 批量更新导致中间缩放量丢失
- 手机端捏合缩放同步改为距离比（`newDist / oldDist`）乘法方式
- 提取所有魔法数字到 canvas.ts（`ZOOM_BASE`、`ZOOM_MIN`、`ZOOM_MAX`、`WHEEL_SENSITIVITY`、`TOUCHPAD_SENSITIVITY` 等）

### 2. 触屏延迟放置与多指过渡 (`ccada3f1`)
- 触屏点击放置车站/杂项节点延迟 150ms（`TOUCH_PLACE_DEFER_MS`），第二根手指按下时取消放置，防止捏合时误创建节点
- 径向菜单检测延迟 80ms（`TOUCH_RADIAL_DEFER_MS`），同理防止捏合误触
- 引入 `pointerCountRef` 追踪活跃指针数量，第二根手指按下时中断背景拖拽并通过 `lastDragViewBoxMinRef` 提交当前视觉位置，防止视口闪回到拖拽前的状态

### 3. 缩放阻尼与单指重新接管 (`46872f7b`)
- 缩放接近 `ZOOM_MIN` / `ZOOM_MAX` 边界时（`ZOOM_DAMPING_RANGE = 30`），逐渐压缩缩放因子产生减速感，替代原来的硬截断
- 双指捏合结束后，剩余的单根手指自动重新接管背景拖拽，无需全部抬起再按下
- 在 `handleTouchMove` 中添加安全兜底，防止多指触摸时定时器泄露

## 其他说明
本功能代码主要由 Claude Sonnet 4.6/Opus 4.6 辅助生成。经过人工测试，确认功能行为符合预期且与现有业务逻辑兼容。