### PR TITLE
#1376 Disable sidebar opening on line creation

### DIFF
--- a/src/components/svg-canvas-graph.tsx
+++ b/src/components/svg-canvas-graph.tsx
@@ -353,6 +353,8 @@ const SvgCanvas = () => {
                     dispatch(refreshEdgesThunk());
                 }
             }
+            // Clear selection after attempting to create a line to prevent the details panel from opening
+            dispatch(clearSelected());
         } else if (mode === 'free') {
             if (active) {
                 // the node is pointed down before


### PR DESCRIPTION
fix #1376
和 #1383 的区别是不论创建失败还是创建成功都不弹出站点侧边栏，只需要修改一行代码。
本pr和 #1383 只需要接受其中一个就能解决 #1376，如果一个pr被接受，请关闭另一个。

## 其他说明
本功能代码主要由 Claude Sonnet 4.6/Opus 4.6/ Gemini 2.5 Pro 辅助生成。经过人工测试，确认功能行为符合预期且与现有业务逻辑兼容。