### PR TITLE
#1219 Fix remove watermark option in image export

### DIFF
--- a/src/components/page-header/download-actions.tsx
+++ b/src/components/page-header/download-actions.tsx
@@ -35,11 +35,11 @@ import { Events } from '../../constants/constants';
 import { isTauri } from '../../constants/server';
 import { useRootDispatch, useRootSelector } from '../../redux';
 import { setGlobalAlert } from '../../redux/runtime/runtime-slice';
-import { downloadAs, downloadBlobAs, makeRenderReadySVGElement, rmpInfoSpecificNodeExists } from '../../util/download';
+import { downloadAs, downloadBlobAs, makeRenderReadySVGElement, shouldForceRmpInfo } from '../../util/download';
 import { isSafari } from '../../util/fonts';
 import { calculateCanvasSize } from '../../util/helpers';
-import { stringifyParam } from '../../util/save';
 import { imageStoreIndexedDB } from '../../util/image-store-indexed-db';
+import { stringifyParam } from '../../util/save';
 import { ToRmgModal } from './rmp-to-rmg';
 import TermsAndConditionsModal from './terms-and-conditions';
 
@@ -125,10 +125,10 @@ export default function DownloadActions() {
     const [isTermsAndConditionsModalOpen, setIsTermsAndConditionsModalOpen] = React.useState(false);
     const [isSystemFontsOnly, setIsSystemFontsOnly] = React.useState(false);
     const [isAttachSelected, setIsAttachSelected] = React.useState(false);
-    const [isAttachDisabled, setIsAttachDisabled] = React.useState(false);
     const [isTermsAndConditionsSelected, setIsTermsAndConditionsSelected] = React.useState(false);
     const [isDownloadRunning, setIsDownloadRunning] = React.useState(false);
     const [isToRmgOpen, setIsToRmgOpen] = React.useState(false);
+    const isRmpInfoForced = shouldForceRmpInfo(existsNodeTypes, RMP_EXPORT);
 
     // calculate the max canvas area the current browser can support
     React.useEffect(() => {
@@ -150,15 +150,14 @@ export default function DownloadActions() {
                 scale => (width * scale) / 100 > maxArea.width && (height * scale) / 100 > maxArea.height
             );
             setResvgScaleOptions(disabledScales);
-
-            if (rmpInfoSpecificNodeExists(existsNodeTypes)) {
-                setIsAttachSelected(false);
-                setIsAttachDisabled(true);
-            } else {
-                setIsAttachDisabled(false);
-            }
         }
     }, [isDownloadModalOpen]);
+
+    React.useEffect(() => {
+        if (isDownloadModalOpen && isRmpInfoForced) {
+            setIsAttachSelected(false);
+        }
+    }, [isDownloadModalOpen, isRmpInfoForced]);
 
     const handleDownloadJson = async () => {
         if (isAllowAppTelemetry)
@@ -194,7 +193,7 @@ export default function DownloadActions() {
             isAttachSelected,
             isSystemFontsOnly,
             languages,
-            existsNodeTypes,
+            isRmpInfoForced,
             svgVersion
         );
         // white spaces will be converted to &nbsp; and will fail the canvas render process
@@ -301,7 +300,7 @@ export default function DownloadActions() {
                             <Checkbox
                                 id="share_info"
                                 isChecked={isAttachSelected}
-                                isDisabled={isAttachDisabled && !RMP_EXPORT}
+                                isDisabled={isRmpInfoForced}
                                 onChange={e => setIsAttachSelected(e.target.checked)}
                             >
                                 <Text>
@@ -312,7 +311,7 @@ export default function DownloadActions() {
                                     {t('header.download.shareInfo2')}
                                 </Text>
                             </Checkbox>
-                            {isAttachDisabled && (
+                            {isRmpInfoForced && (
                                 <Badge ml="1" color="gray.50" background="radial-gradient(circle, #3f5efb, #fc466b)">
                                     PRO
                                 </Badge>
@@ -332,7 +331,7 @@ export default function DownloadActions() {
                             </Text>
                         </Checkbox>
 
-                        {isAttachDisabled && (
+                        {isRmpInfoForced && (
                             <Alert status="error" mt="4">
                                 <AlertIcon />
                                 <Box>

--- a/src/util/download.test.ts
+++ b/src/util/download.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import type { NodeType } from '../constants/constants';
+import { MiscNodeType } from '../constants/nodes';
+import { StationType } from '../constants/stations';
+import { rmpInfoSpecificNodeExists, shouldForceRmpInfo } from './download';
+
+describe('download RMP info rules', () => {
+    it('detects image and fill nodes as requiring RMP info handling', () => {
+        expect(rmpInfoSpecificNodeExists(new Set<NodeType>([MiscNodeType.Image]))).toBe(true);
+        expect(rmpInfoSpecificNodeExists(new Set<NodeType>([MiscNodeType.Fill]))).toBe(true);
+        expect(rmpInfoSpecificNodeExists(new Set<NodeType>([StationType.ShmetroBasic]))).toBe(false);
+    });
+
+    it('only forces embedded RMP info for non-subscribers with image or fill nodes', () => {
+        expect(shouldForceRmpInfo(new Set<NodeType>([MiscNodeType.Image]), false)).toBe(true);
+        expect(shouldForceRmpInfo(new Set<NodeType>([MiscNodeType.Fill]), false)).toBe(true);
+        expect(shouldForceRmpInfo(new Set<NodeType>([MiscNodeType.Image]), true)).toBe(false);
+        expect(shouldForceRmpInfo(new Set<NodeType>([StationType.ShmetroBasic]), false)).toBe(false);
+    });
+});

--- a/src/util/download.ts
+++ b/src/util/download.ts
@@ -30,16 +30,17 @@ export const downloadBlobAs = (filename: string, blob: Blob) => {
  * Clone the svg element and add fonts & missing external svg to it.
  * The returned svg should be opened and displayed correctly in any svg viewer.
  * @param graph The graph.
- * @param generateRMPInfo Whether to call `generateRmpInfo`.
+ * @param isShareInfoAttached Whether the user confirmed they will attach RMP info when sharing the image.
  * @param isSystemFontsOnly Whether to add font-family to elements with fonts classes.
+ * @param forceRMPInfo Whether RMP info must be embedded regardless of the user's confirmation.
  * @returns The all in one SVGSVGElement and the size of canvas.
  */
 export const makeRenderReadySVGElement = async (
     graph: MultiDirectedGraph<NodeAttributes, EdgeAttributes, GraphAttributes>,
-    generateRMPInfo: boolean,
+    isShareInfoAttached: boolean,
     isSystemFontsOnly: boolean,
     languages: TextLanguage[],
-    existsNodeTypes: Set<NodeType>,
+    forceRMPInfo: boolean,
     svgVersion: 1.1 | 2
 ) => {
     // get the minimum and maximum of the graph
@@ -115,8 +116,8 @@ export const makeRenderReadySVGElement = async (
 
     await loadFacilitiesSvg(elem, graph);
 
-    // append rmp info if some nodes exist
-    if (!generateRMPInfo || rmpInfoSpecificNodeExists(existsNodeTypes)) {
+    // append RMP info unless the user confirms external attribution and no node forces embedded attribution.
+    if (!isShareInfoAttached || forceRMPInfo) {
         // intelligent placement to avoid overlapping existing elements.
         const [infoX, infoY] = findRmpInfoPosition(graph, { xMin, yMin, xMax, yMax }, { width: 350, height: 50 });
         elem.appendChild(await generateRmpInfo(infoX, infoY));
@@ -191,6 +192,10 @@ export const rmpInfoSpecificNodeExists = (existsNodeTypes: Set<NodeType>) => {
         return true;
     }
     return false;
+};
+
+export const shouldForceRmpInfo = (existsNodeTypes: Set<NodeType>, hasRmpExportSubscription: boolean) => {
+    return rmpInfoSpecificNodeExists(existsNodeTypes) && !hasRmpExportSubscription;
 };
 
 // Intelligent placement using candidate positions; overlap detection via graph traversal.


### PR DESCRIPTION
Fixes #1219.

## Summary
- Align the export watermark enforcement with the RMP_EXPORT subscription state.
- Only force embedded RMP info for image/fill nodes when the user does not have an export subscription.
- Remove the stale derived disabled state from the export modal and add unit coverage for the attribution rule.

## Verification
- npx tsc --noEmit
- npm run lint
- npm test