### PR TITLE
#1454 Refactor GlobalAlerts

### DIFF
--- a/src/components/page-header/download-actions.tsx
+++ b/src/components/page-header/download-actions.tsx
@@ -31,6 +31,7 @@ import React from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { MdDownload, MdImage, MdOpenInNew, MdSave, MdSaveAs } from 'react-icons/md';
 import { Events } from '../../constants/constants';
+import { GlobalAlertId } from '../../constants/global-alerts';
 import { isTauri } from '../../constants/server';
 import { useRootDispatch, useRootSelector } from '../../redux';
 import { setGlobalAlert } from '../../redux/runtime/runtime-slice';
@@ -246,7 +247,13 @@ export default function DownloadActions() {
                         setIsDownloadRunning(false);
                         if (!blob) {
                             // The canvas size is bigger than the current browser can support.
-                            dispatch(setGlobalAlert({ status: 'error', message: t('header.download.imageTooBig') }));
+                            dispatch(
+                                setGlobalAlert({
+                                    id: GlobalAlertId.DownloadImageTooBig,
+                                    status: 'error',
+                                    message: t('header.download.imageTooBig'),
+                                })
+                            );
                             return;
                         }
                         downloadBlobAs(`RMP_${new Date().valueOf()}.png`, blob!);

--- a/src/components/page-header/global-alerts.test.tsx
+++ b/src/components/page-header/global-alerts.test.tsx
@@ -1,29 +1,34 @@
-import { screen, within } from '@testing-library/react';
+import { fireEvent, screen, within } from '@testing-library/react';
 import React from 'react';
 import { describe, expect, it } from 'vitest';
+import { GlobalAlertId } from '../../constants/global-alerts';
 import rootReducer, { createStore } from '../../redux';
+import { setGlobalAlert } from '../../redux/runtime/runtime-slice';
 import { render } from '../../test-utils';
 import GlobalAlerts from './global-alerts';
 
 const realStore = rootReducer.getState();
-const mockStore = createStore({
-    runtime: {
-        ...realStore.runtime,
-        globalAlerts: {
-            info: {
-                message: 'Test info message',
-                url: 'https://example.com',
-            },
-            warning: {
-                message: 'Test warning message',
+const createMockStore = () =>
+    createStore({
+        runtime: {
+            ...realStore.runtime,
+            globalAlerts: {
+                [GlobalAlertId.LocalStorageQuotaExceeded]: {
+                    status: 'info',
+                    message: 'Test info message',
+                    url: 'https://example.com',
+                },
+                [GlobalAlertId.MasterNodeLimitExceeded]: {
+                    status: 'warning',
+                    message: 'Test warning message',
+                },
             },
         },
-    },
-});
+    });
 
 describe('GlobalAlerts', () => {
     it('Can render alerts in correct order as expected', () => {
-        render(<GlobalAlerts />, { store: mockStore });
+        render(<GlobalAlerts />, { store: createMockStore() });
 
         // order matters
         const alerts = screen.getAllByRole('alert');
@@ -33,5 +38,25 @@ describe('GlobalAlerts', () => {
 
         // can render link
         expect(within(alerts[0]).getByRole('link')).toBeInTheDocument();
+    });
+
+    it('closes an alert by id without dismissing another alert with the same status', () => {
+        const mockStore = createMockStore();
+        mockStore.dispatch(
+            setGlobalAlert({
+                id: GlobalAlertId.ParallelLineLimitExceeded,
+                status: 'warning',
+                message: 'Test parallel warning',
+            })
+        );
+        render(<GlobalAlerts />, { store: mockStore });
+
+        fireEvent.click(
+            within(screen.getByText('Test warning message').closest('[role="alert"]')!).getByRole('button')
+        );
+
+        expect(screen.queryByText('Test warning message')).not.toBeInTheDocument();
+        expect(screen.getByText('Test parallel warning')).toBeInTheDocument();
+        expect(mockStore.getState().runtime.globalAlerts[GlobalAlertId.MasterNodeLimitExceeded]).toBeUndefined();
     });
 });

--- a/src/components/page-header/global-alerts.tsx
+++ b/src/components/page-header/global-alerts.tsx
@@ -1,5 +1,6 @@
-import { Alert, AlertIcon, AlertStatus, CloseButton, Link } from '@chakra-ui/react';
+import { Alert, AlertIcon, CloseButton, Link } from '@chakra-ui/react';
 import rmgRuntime from '@railmapgen/rmg-runtime';
+import { GlobalAlertId } from '../../constants/global-alerts';
 import { useRootDispatch, useRootSelector } from '../../redux';
 import { closeGlobalAlert } from '../../redux/runtime/runtime-slice';
 
@@ -18,17 +19,8 @@ export default function GlobalAlerts() {
 
     return (
         <>
-            {Object.entries(globalAlerts).map(([status, { message, url, linkedApp }]) => (
-                <Alert
-                    key={status}
-                    status={status as AlertStatus}
-                    variant="solid"
-                    size="xs"
-                    pl={3}
-                    pr={1}
-                    py={0}
-                    zIndex="1"
-                >
+            {Object.entries(globalAlerts).map(([id, { status, message, url, linkedApp }]) => (
+                <Alert key={id} status={status} variant="solid" size="xs" pl={3} pr={1} py={0} zIndex="1">
                     <AlertIcon />
                     {linkedApp ? (
                         <Link onClick={() => handleAppOpen(linkedApp)}>{message}</Link>
@@ -39,7 +31,7 @@ export default function GlobalAlerts() {
                     ) : (
                         message
                     )}
-                    <CloseButton ml="auto" onClick={() => dispatch(closeGlobalAlert(status as AlertStatus))} />
+                    <CloseButton ml="auto" onClick={() => dispatch(closeGlobalAlert(id as GlobalAlertId))} />
                 </Alert>
             ))}
         </>

--- a/src/components/page-header/open-actions.tsx
+++ b/src/components/page-header/open-actions.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { MdInsertDriveFile, MdNoteAdd, MdOpenInNew, MdSchool, MdUpload } from 'react-icons/md';
 import { Events, LocalStorageKey } from '../../constants/constants';
+import { GlobalAlertId } from '../../constants/global-alerts';
 import { useRootDispatch } from '../../redux';
 import { saveGraph, setSvgViewBoxMin, setSvgViewBoxZoom } from '../../redux/param/param-slice';
 import { clearSelected, refreshEdgesThunk, refreshNodesThunk, setGlobalAlert } from '../../redux/runtime/runtime-slice';
@@ -100,7 +101,13 @@ export default function OpenActions() {
         logger.debug('OpenActions.handleUpload():: received file', file);
 
         if (file?.type !== 'application/json') {
-            dispatch(setGlobalAlert({ status: 'error', message: t('header.open.invalidType') }));
+            dispatch(
+                setGlobalAlert({
+                    id: GlobalAlertId.OpenInvalidFileType,
+                    status: 'error',
+                    message: t('header.open.invalidType'),
+                })
+            );
             logger.error('OpenActions.handleUpload():: Invalid file type! Only file in JSON format is accepted.');
         } else {
             try {
@@ -110,7 +117,13 @@ export default function OpenActions() {
                 setVersionToLoad(version);
                 onConfirmOpen();
             } catch (err) {
-                dispatch(setGlobalAlert({ status: 'error', message: t('header.open.unknownError') }));
+                dispatch(
+                    setGlobalAlert({
+                        id: GlobalAlertId.OpenFileFailed,
+                        status: 'error',
+                        message: t('header.open.unknownError'),
+                    })
+                );
                 logger.error(
                     'OpenActions.handleUpload():: Unknown error occurred while parsing the uploaded file',
                     err

--- a/src/components/page-header/rmg-param-app-clip.tsx
+++ b/src/components/page-header/rmg-param-app-clip.tsx
@@ -4,6 +4,7 @@ import rmgRuntime, { logger } from '@railmapgen/rmg-runtime';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Events } from '../../constants/constants';
+import { GlobalAlertId } from '../../constants/global-alerts';
 import { RMGParam } from '../../constants/rmg';
 import { useRootDispatch, useRootSelector } from '../../redux';
 import { saveGraph } from '../../redux/param/param-slice';
@@ -67,7 +68,13 @@ export default function RmgParamAppClip(props: RmgAppClipProps) {
             parseRmgParam(graph.current, param, x, y, autoParallel);
             refreshAndSave();
         } catch (err) {
-            dispatch(setGlobalAlert({ status: 'error', message: t('header.open.unknownError') }));
+            dispatch(
+                setGlobalAlert({
+                    id: GlobalAlertId.ImportRmgProjectFailed,
+                    status: 'error',
+                    message: t('header.open.unknownError'),
+                })
+            );
             logger.error('OpenActions.handleUploadRMG():: Unknown error occurred while parsing the RMG project', err);
         } finally {
             onClose();

--- a/src/constants/global-alerts.ts
+++ b/src/constants/global-alerts.ts
@@ -1,0 +1,13 @@
+/**
+ * Stable identities let the code that owns an alert update or dismiss it
+ * without affecting unrelated alerts that happen to share the same status.
+ */
+export enum GlobalAlertId {
+    MasterNodeLimitExceeded = 'master-node-limit-exceeded',
+    ParallelLineLimitExceeded = 'parallel-line-limit-exceeded',
+    LocalStorageQuotaExceeded = 'local-storage-quota-exceeded',
+    OpenInvalidFileType = 'open-invalid-file-type',
+    OpenFileFailed = 'open-file-failed',
+    ImportRmgProjectFailed = 'import-rmg-project-failed',
+    DownloadImageTooBig = 'download-image-too-big',
+}

--- a/src/redux/init.ts
+++ b/src/redux/init.ts
@@ -1,6 +1,7 @@
 import rmgRuntime, { logger } from '@railmapgen/rmg-runtime';
 import { MultiDirectedGraph } from 'graphology';
 import { EdgeAttributes, GraphAttributes, LocalStorageKey, NodeAttributes } from '../constants/constants';
+import { GlobalAlertId } from '../constants/global-alerts';
 import i18n from '../i18n/config';
 import { onLocalStorageChangeRMT, onRMPSaveUpdate } from '../util/rmt-save';
 import { RMPSave, stringifyParam, upgrade } from '../util/save';
@@ -131,7 +132,9 @@ export const initStore = async (store: RootStore) => {
                 if (error instanceof Error && error.name == 'QuotaExceededError') {
                     logger.error('Local storage quota exceeded, unable to save state.');
                     const message = i18n.t('localStorageQuotaExceeded');
-                    listenerApi.dispatch(setGlobalAlert({ status: 'error', message }));
+                    listenerApi.dispatch(
+                        setGlobalAlert({ id: GlobalAlertId.LocalStorageQuotaExceeded, status: 'error', message })
+                    );
                 }
             }
         },
@@ -148,7 +151,9 @@ export const initStore = async (store: RootStore) => {
                 if (error instanceof Error && error.name == 'QuotaExceededError') {
                     logger.error('Local storage quota exceeded, unable to save state.');
                     const message = i18n.t('localStorageQuotaExceeded');
-                    listenerApi.dispatch(setGlobalAlert({ status: 'error', message }));
+                    listenerApi.dispatch(
+                        setGlobalAlert({ id: GlobalAlertId.LocalStorageQuotaExceeded, status: 'error', message })
+                    );
                 }
             }
         },
@@ -165,7 +170,9 @@ export const initStore = async (store: RootStore) => {
                 if (error instanceof Error && error.name == 'QuotaExceededError') {
                     logger.error('Local storage quota exceeded, unable to save state.');
                     const message = i18n.t('localStorageQuotaExceeded');
-                    listenerApi.dispatch(setGlobalAlert({ status: 'error', message }));
+                    listenerApi.dispatch(
+                        setGlobalAlert({ id: GlobalAlertId.LocalStorageQuotaExceeded, status: 'error', message })
+                    );
                 }
             }
         },

--- a/src/redux/runtime/runtime-slice.test.ts
+++ b/src/redux/runtime/runtime-slice.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'vitest';
+import { GlobalAlertId } from '../../constants/global-alerts';
 import store from '../index';
 import { redoAction, undoAction } from '../param/param-slice';
-import appReducer from './runtime-slice';
+import appReducer, { closeGlobalAlert, setGlobalAlert } from './runtime-slice';
 
 const realStore = store.getState();
 
@@ -16,5 +17,98 @@ describe('ParamSlice', () => {
         const nextState = appReducer(realStore.runtime, redoAction());
         expect(nextState.refresh.nodes).not.toEqual(realStore.runtime.refresh.nodes);
         expect(nextState.refresh.edges).not.toEqual(realStore.runtime.refresh.edges);
+    });
+});
+
+describe('global alerts', () => {
+    it('keeps alerts from different businesses even when their statuses match', () => {
+        const withMasterAlert = appReducer(
+            realStore.runtime,
+            setGlobalAlert({
+                id: GlobalAlertId.MasterNodeLimitExceeded,
+                status: 'warning',
+                message: 'Master limit exceeded',
+            })
+        );
+        const withBothAlerts = appReducer(
+            withMasterAlert,
+            setGlobalAlert({
+                id: GlobalAlertId.ParallelLineLimitExceeded,
+                status: 'warning',
+                message: 'Parallel limit exceeded',
+            })
+        );
+
+        expect(withBothAlerts.globalAlerts).toMatchObject({
+            [GlobalAlertId.MasterNodeLimitExceeded]: {
+                status: 'warning',
+                message: 'Master limit exceeded',
+            },
+            [GlobalAlertId.ParallelLineLimitExceeded]: {
+                status: 'warning',
+                message: 'Parallel limit exceeded',
+            },
+        });
+    });
+
+    it('replaces an existing alert with the same id', () => {
+        const firstState = appReducer(
+            realStore.runtime,
+            setGlobalAlert({
+                id: GlobalAlertId.OpenFileFailed,
+                status: 'error',
+                message: 'First failure',
+                url: 'https://example.com/first',
+            })
+        );
+        const nextState = appReducer(
+            firstState,
+            setGlobalAlert({
+                id: GlobalAlertId.OpenFileFailed,
+                status: 'warning',
+                message: 'Updated failure',
+            })
+        );
+
+        expect(nextState.globalAlerts).toEqual({
+            [GlobalAlertId.OpenFileFailed]: {
+                status: 'warning',
+                message: 'Updated failure',
+                url: undefined,
+                linkedApp: undefined,
+            },
+        });
+    });
+
+    it('closes only the requested alert and ignores an unknown id', () => {
+        const withMasterAlert = appReducer(
+            realStore.runtime,
+            setGlobalAlert({
+                id: GlobalAlertId.MasterNodeLimitExceeded,
+                status: 'warning',
+                message: 'Master limit exceeded',
+            })
+        );
+        const withBothAlerts = appReducer(
+            withMasterAlert,
+            setGlobalAlert({
+                id: GlobalAlertId.ParallelLineLimitExceeded,
+                status: 'warning',
+                message: 'Parallel limit exceeded',
+            })
+        );
+
+        const afterUnknownId = appReducer(withBothAlerts, closeGlobalAlert(GlobalAlertId.DownloadImageTooBig));
+        expect(afterUnknownId).toBe(withBothAlerts);
+
+        const afterClose = appReducer(afterUnknownId, closeGlobalAlert(GlobalAlertId.MasterNodeLimitExceeded));
+        expect(afterClose.globalAlerts).toEqual({
+            [GlobalAlertId.ParallelLineLimitExceeded]: {
+                status: 'warning',
+                message: 'Parallel limit exceeded',
+                url: undefined,
+                linkedApp: undefined,
+            },
+        });
     });
 });

--- a/src/redux/runtime/runtime-slice.test.ts
+++ b/src/redux/runtime/runtime-slice.test.ts
@@ -1,8 +1,14 @@
+import { MultiDirectedGraph } from 'graphology';
 import { describe, expect, it } from 'vitest';
+import { EdgeAttributes, GraphAttributes, NodeAttributes } from '../../constants/constants';
 import { GlobalAlertId } from '../../constants/global-alerts';
-import store from '../index';
+import { LinePathType } from '../../constants/lines';
+import { MAX_MASTER_NODE_FREE } from '../../constants/master';
+import { MiscNodeType } from '../../constants/nodes';
+import { MAX_PARALLEL_LINES_FREE } from '../../util/parallel';
+import store, { createStore } from '../index';
 import { redoAction, undoAction } from '../param/param-slice';
-import appReducer, { closeGlobalAlert, setGlobalAlert } from './runtime-slice';
+import appReducer, { closeGlobalAlert, refreshEdgesThunk, refreshNodesThunk, setGlobalAlert } from './runtime-slice';
 
 const realStore = store.getState();
 
@@ -21,6 +27,44 @@ describe('ParamSlice', () => {
 });
 
 describe('global alerts', () => {
+    it('clears the master limit warning after the graph returns within the free limit', async () => {
+        const graph = new MultiDirectedGraph<NodeAttributes, EdgeAttributes, GraphAttributes>();
+        for (let index = 0; index <= MAX_MASTER_NODE_FREE; index += 1) {
+            graph.addNode(`misc_node_master_${index}`, { type: MiscNodeType.Master } as NodeAttributes);
+        }
+        window.graph = graph;
+        const testStore = createStore();
+
+        await testStore.dispatch(refreshNodesThunk());
+        expect(testStore.getState().runtime.globalAlerts).toHaveProperty(GlobalAlertId.MasterNodeLimitExceeded);
+
+        graph.dropNode('misc_node_master_0');
+        await testStore.dispatch(refreshNodesThunk());
+        expect(testStore.getState().runtime.globalAlerts).not.toHaveProperty(GlobalAlertId.MasterNodeLimitExceeded);
+    });
+
+    it('clears the parallel limit warning after the graph returns within the free limit', async () => {
+        const graph = new MultiDirectedGraph<NodeAttributes, EdgeAttributes, GraphAttributes>();
+        const nodeAttributes = { type: MiscNodeType.Virtual } as NodeAttributes;
+        graph.addNode('misc_node_from', nodeAttributes);
+        graph.addNode('misc_node_to', nodeAttributes);
+        for (let index = 0; index <= MAX_PARALLEL_LINES_FREE; index += 1) {
+            graph.addDirectedEdgeWithKey(`line_parallel_${index}`, 'misc_node_from', 'misc_node_to', {
+                type: LinePathType.Diagonal,
+                parallelIndex: index,
+            } as EdgeAttributes);
+        }
+        window.graph = graph;
+        const testStore = createStore();
+
+        await testStore.dispatch(refreshEdgesThunk());
+        expect(testStore.getState().runtime.globalAlerts).toHaveProperty(GlobalAlertId.ParallelLineLimitExceeded);
+
+        graph.dropEdge('line_parallel_0');
+        await testStore.dispatch(refreshEdgesThunk());
+        expect(testStore.getState().runtime.globalAlerts).not.toHaveProperty(GlobalAlertId.ParallelLineLimitExceeded);
+    });
+
     it('keeps alerts from different businesses even when their statuses match', () => {
         const withMasterAlert = appReducer(
             realStore.runtime,

--- a/src/redux/runtime/runtime-slice.ts
+++ b/src/redux/runtime/runtime-slice.ts
@@ -163,6 +163,9 @@ export const refreshNodesThunk = createAsyncThunk('runtime/refreshNodes', async 
                 message: `${i18n.t('header.settings.proLimitExceed.master')} ${i18n.t('header.settings.proLimitExceed.solution')}`,
             })
         );
+    } else {
+        // The warning describes current graph validity, so it must not outlive the condition that created it.
+        dispatch(closeGlobalAlert(GlobalAlertId.MasterNodeLimitExceeded));
     }
 
     const existsNodeTypes = Object.keys(existsNodeTypesCount) as NodeType[];
@@ -197,6 +200,9 @@ export const refreshEdgesThunk = createAsyncThunk('runtime/refreshEdges', async 
                 message: `${i18n.t('header.settings.proLimitExceed.parallel')} ${i18n.t('header.settings.proLimitExceed.solution')}`,
             })
         );
+    } else {
+        // A stable ID lets this refresh clear only its own recovered limit without touching other warnings.
+        dispatch(closeGlobalAlert(GlobalAlertId.ParallelLineLimitExceeded));
     }
 });
 

--- a/src/redux/runtime/runtime-slice.ts
+++ b/src/redux/runtime/runtime-slice.ts
@@ -6,6 +6,7 @@ import type { Draft } from 'immer';
 import { RootState } from '..';
 import { defaultRadialTouchMenuState, RadialTouchMenuState } from '../../components/touch/radial-touch-menu';
 import { CityCode, Id, NodeId, NodeType, RuntimeMode, StationCity, Theme } from '../../constants/constants';
+import { GlobalAlertId } from '../../constants/global-alerts';
 import { MAX_MASTER_NODE_FREE, MAX_MASTER_NODE_PRO } from '../../constants/master';
 import { MiscNodeType } from '../../constants/nodes';
 import { STATION_TYPE_VALUES, StationType } from '../../constants/stations';
@@ -90,7 +91,9 @@ interface RuntimeState {
      */
     existsNodeTypes: Set<NodeType>;
     radialTouchMenu: RadialTouchMenuState;
-    globalAlerts: Partial<Record<AlertStatus, { message: string; url?: string; linkedApp?: string }>>;
+    globalAlerts: Partial<
+        Record<GlobalAlertId, { status: AlertStatus; message: string; url?: string; linkedApp?: string }>
+    >;
 }
 
 const initialState: RuntimeState = {
@@ -155,6 +158,7 @@ export const refreshNodesThunk = createAsyncThunk('runtime/refreshNodes', async 
     if (masters > maximumMasterNodes) {
         dispatch(
             setGlobalAlert({
+                id: GlobalAlertId.MasterNodeLimitExceeded,
                 status: 'warning',
                 message: `${i18n.t('header.settings.proLimitExceed.master')} ${i18n.t('header.settings.proLimitExceed.solution')}`,
             })
@@ -188,6 +192,7 @@ export const refreshEdgesThunk = createAsyncThunk('runtime/refreshEdges', async 
     if (parallelLinesCount > maximumParallelLines) {
         dispatch(
             setGlobalAlert({
+                id: GlobalAlertId.ParallelLineLimitExceeded,
                 status: 'warning',
                 message: `${i18n.t('header.settings.proLimitExceed.parallel')} ${i18n.t('header.settings.proLimitExceed.solution')}`,
             })
@@ -321,12 +326,18 @@ const runtimeSlice = createSlice({
          */
         setGlobalAlert: (
             state,
-            action: PayloadAction<{ status: AlertStatus; message: string; url?: string; linkedApp?: string }>
+            action: PayloadAction<{
+                id: GlobalAlertId;
+                status: AlertStatus;
+                message: string;
+                url?: string;
+                linkedApp?: string;
+            }>
         ) => {
-            const { status, message, url, linkedApp } = action.payload;
-            state.globalAlerts[status] = { message, url, linkedApp };
+            const { id, status, message, url, linkedApp } = action.payload;
+            state.globalAlerts[id] = { status, message, url, linkedApp };
         },
-        closeGlobalAlert: (state, action: PayloadAction<AlertStatus>) => {
+        closeGlobalAlert: (state, action: PayloadAction<GlobalAlertId>) => {
             delete state.globalAlerts[action.payload];
         },
     },

--- a/src/util/rmt-save.test.ts
+++ b/src/util/rmt-save.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { GlobalAlertId } from '../constants/global-alerts';
+import { createStore } from '../redux';
+import { APISubscription, fetchLoginStateAndSubscriptions } from './rmt-save';
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+});
+
+const createStoreWithLimitAlerts = () => {
+    const initialState = createStore().getState();
+    return createStore({
+        runtime: {
+            ...initialState.runtime,
+            globalAlerts: {
+                [GlobalAlertId.MasterNodeLimitExceeded]: {
+                    status: 'warning',
+                    message: 'Master limit exceeded',
+                },
+                [GlobalAlertId.ParallelLineLimitExceeded]: {
+                    status: 'warning',
+                    message: 'Parallel limit exceeded',
+                },
+            },
+        },
+    });
+};
+
+const mockSubscriptions = (subscriptions: APISubscription[]) => {
+    vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+            status: 200,
+            json: async () => ({ subscriptions }),
+        })
+    );
+};
+
+describe('fetchLoginStateAndSubscriptions', () => {
+    it('closes only the master limit alert when RMP Cloud is active', async () => {
+        mockSubscriptions([{ type: 'RMP_CLOUD', expires: '2099-01-01T00:00:00Z' }]);
+        const store = createStoreWithLimitAlerts();
+
+        await fetchLoginStateAndSubscriptions(store.dispatch, 'token');
+
+        expect(store.getState().runtime.globalAlerts).toEqual({
+            [GlobalAlertId.ParallelLineLimitExceeded]: {
+                status: 'warning',
+                message: 'Parallel limit exceeded',
+            },
+        });
+    });
+
+    it('does not close the master limit alert for an unrelated subscription', async () => {
+        mockSubscriptions([{ type: 'RMP_EXPORT', expires: '2099-01-01T00:00:00Z' }]);
+        const store = createStoreWithLimitAlerts();
+
+        await fetchLoginStateAndSubscriptions(store.dispatch, 'token');
+
+        expect(store.getState().runtime.globalAlerts).toHaveProperty(GlobalAlertId.MasterNodeLimitExceeded);
+    });
+});

--- a/src/util/rmt-save.test.ts
+++ b/src/util/rmt-save.test.ts
@@ -37,18 +37,13 @@ const mockSubscriptions = (subscriptions: APISubscription[]) => {
 };
 
 describe('fetchLoginStateAndSubscriptions', () => {
-    it('closes only the master limit alert when RMP Cloud is active', async () => {
+    it('closes all RMP Cloud limit alerts when RMP Cloud is active', async () => {
         mockSubscriptions([{ type: 'RMP_CLOUD', expires: '2099-01-01T00:00:00Z' }]);
         const store = createStoreWithLimitAlerts();
 
         await fetchLoginStateAndSubscriptions(store.dispatch, 'token');
 
-        expect(store.getState().runtime.globalAlerts).toEqual({
-            [GlobalAlertId.ParallelLineLimitExceeded]: {
-                status: 'warning',
-                message: 'Parallel limit exceeded',
-            },
-        });
+        expect(store.getState().runtime.globalAlerts).toEqual({});
     });
 
     it('does not close the master limit alert for an unrelated subscription', async () => {
@@ -58,5 +53,6 @@ describe('fetchLoginStateAndSubscriptions', () => {
         await fetchLoginStateAndSubscriptions(store.dispatch, 'token');
 
         expect(store.getState().runtime.globalAlerts).toHaveProperty(GlobalAlertId.MasterNodeLimitExceeded);
+        expect(store.getState().runtime.globalAlerts).toHaveProperty(GlobalAlertId.ParallelLineLimitExceeded);
     });
 });

--- a/src/util/rmt-save.ts
+++ b/src/util/rmt-save.ts
@@ -1,5 +1,6 @@
 import { logger } from '@railmapgen/rmg-runtime';
 import { LocalStorageKey } from '../constants/constants';
+import { GlobalAlertId } from '../constants/global-alerts';
 import { subscription_endpoint } from '../constants/server';
 import { createStore, RootDispatch } from '../redux';
 import {
@@ -9,6 +10,7 @@ import {
     setState,
     setToken,
 } from '../redux/account/account-slice';
+import { closeGlobalAlert } from '../redux/runtime/runtime-slice';
 
 export const SAVE_MANAGER_CHANNEL_NAME = 'rmt-save-manager';
 export enum SaveManagerEventType {
@@ -70,6 +72,9 @@ export const fetchLoginStateAndSubscriptions = async (dispatch: RootDispatch, to
         }
     }
     dispatch(setActiveSubscriptions(activeSubscriptions));
+    if (activeSubscriptions.RMP_CLOUD) {
+        dispatch(closeGlobalAlert(GlobalAlertId.MasterNodeLimitExceeded));
+    }
     logger.debug(`Token is valid, setting active subscriptions: ${JSON.stringify(activeSubscriptions)}`);
 };
 

--- a/src/util/rmt-save.ts
+++ b/src/util/rmt-save.ts
@@ -74,6 +74,7 @@ export const fetchLoginStateAndSubscriptions = async (dispatch: RootDispatch, to
     dispatch(setActiveSubscriptions(activeSubscriptions));
     if (activeSubscriptions.RMP_CLOUD) {
         dispatch(closeGlobalAlert(GlobalAlertId.MasterNodeLimitExceeded));
+        dispatch(closeGlobalAlert(GlobalAlertId.ParallelLineLimitExceeded));
     }
     logger.debug(`Token is valid, setting active subscriptions: ${JSON.stringify(activeSubscriptions)}`);
 };


### PR DESCRIPTION
## 改动内容

- 将全局提示从按 `status` 分桶改为按必填的稳定 `id` 分桶。
- 集中定义现有提示的 `GlobalAlertId`，相同业务提示继续覆盖更新，不同业务提示即使状态相同也可同时显示。
- 更新提示组件，使渲染 key 和关闭操作都使用提示 ID，并保留现有样式、外链和应用跳转行为。
- 为所有现有 `setGlobalAlert` 调用补充语义 ID。
- 登录后确认 `RMP_CLOUD` 订阅有效时，精确关闭大师节点额度提示。

## 原因

原实现按 Chakra UI 的展示状态存储提示，因此所有 `warning` 共用一个槽位，后续代码只能按状态关闭。登录后如果用户取得 RMP Cloud 权限，旧的大师节点额度提示无法被安全关闭：直接关闭 `warning` 可能误关另一个业务提示。

按业务 ID 管理提示后，提示的视觉状态不再承担身份职责，调用方可以精确更新或关闭自己拥有的提示。

## 用户影响

- 修复登录成为 RMP Cloud 订阅用户后，大师节点超额提示仍然保留的问题。
- 大师节点和平行线额度提示可以同时显示并分别关闭。
- `RMP_EXPORT` 订阅不会触发大师节点提示关闭。

## 验证

- `npx tsc --noEmit`
- `npm run lint`
- `npm test`（49 个测试文件、325 个测试）
- `git diff --check`

Closes #1454
