### PR TITLE
#1554 Fix Osaka Metro station code font

### DIFF
--- a/src/components/svgs/stations/osaka-metro.test.tsx
+++ b/src/components/svgs/stations/osaka-metro.test.tsx
@@ -1,0 +1,56 @@
+import { render } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { StationType } from '../../../constants/stations';
+import { render as renderWithProviders } from '../../../test-utils';
+import { Node2Font, TextLanguage } from '../../../util/fonts';
+import stations from './stations';
+
+const osakaMetroStation = stations[StationType.OsakaMetro];
+const Station = osakaMetroStation.component;
+const ROBOTO_FONT_FAMILY = 'Roboto, Arial, Helvetica, sans-serif';
+
+const renderStation = (stationType: 'normal' | 'through', lineCode: string) => {
+    const attrs = structuredClone(osakaMetroStation.defaultAttrs);
+    attrs.stationType = stationType;
+    attrs.transfer[0][0][4] = lineCode;
+
+    return renderWithProviders(
+        <svg>
+            <Station
+                id="stn_test"
+                x={0}
+                y={0}
+                attrs={{ [StationType.OsakaMetro]: attrs }}
+                handlePointerDown={vi.fn()}
+                handlePointerMove={vi.fn()}
+                handlePointerUp={vi.fn()}
+            />
+        </svg>
+    );
+};
+
+describe('OsakaMetroStation', () => {
+    it.each([
+        ['normal', 'M', ['M16']],
+        ['through', 'M', ['M16']],
+        ['through', 'MM', ['MM', '16']],
+    ] as const)('uses Roboto for %s station codes', (stationType, lineCode, expectedTexts) => {
+        const { container } = renderStation(stationType, lineCode);
+
+        for (const expectedText of expectedTexts) {
+            const text = Array.from(container.querySelectorAll('text')).find(node => node.textContent === expectedText);
+            expect(text).toHaveAttribute('font-family', ROBOTO_FONT_FAMILY);
+        }
+    });
+
+    it('uses Roboto for the station picker icon', () => {
+        const { container } = render(<svg>{osakaMetroStation.icon}</svg>);
+
+        expect(container.querySelector('text')).toHaveAttribute('font-family', ROBOTO_FONT_FAMILY);
+    });
+
+    it('loads the station name and station code fonts', () => {
+        expect(Node2Font[StationType.OsakaMetro]).toEqual([TextLanguage.tokyo_ja, TextLanguage.berlin]);
+    });
+});

--- a/src/components/svgs/stations/osaka-metro.tsx
+++ b/src/components/svgs/stations/osaka-metro.tsx
@@ -84,6 +84,7 @@ const OsakaMetroStationIcon = (
             fill="currentColor"
         />
         <text
+            {...getLangStyle(TextLanguage.berlin)}
             x="12"
             y="12"
             transform={`translate(0, ${LAYOUT_CONSTANTS.STATION.FONT_SIZE * LAYOUT_CONSTANTS.ICON_RATIO * 0.4})`}
@@ -112,6 +113,7 @@ const OsakaMetroSvg = (props: { interchangeInfo: InterchangeInfo; stationType: O
                 fill={bgColor}
             />
             <text
+                {...getLangStyle(TextLanguage.berlin)}
                 y={(LAYOUT_CONSTANTS.STATION.HEIGHT - LAYOUT_CONSTANTS.STATION.FONT_SIZE) / 2}
                 textAnchor="middle"
                 fontSize={LAYOUT_CONSTANTS.STATION.FONT_SIZE}
@@ -133,6 +135,7 @@ const OsakaMetroSvg = (props: { interchangeInfo: InterchangeInfo; stationType: O
             />
             {lineCode.length === 1 ? (
                 <text
+                    {...getLangStyle(TextLanguage.berlin)}
                     y={(LAYOUT_CONSTANTS.STATION.HEIGHT - LAYOUT_CONSTANTS.STATION.FONT_SIZE) / 2 - 0.5}
                     textAnchor="middle"
                     fontSize={LAYOUT_CONSTANTS.STATION.FONT_SIZE - 2}
@@ -144,6 +147,7 @@ const OsakaMetroSvg = (props: { interchangeInfo: InterchangeInfo; stationType: O
             ) : (
                 <>
                     <text
+                        {...getLangStyle(TextLanguage.berlin)}
                         textAnchor="middle"
                         fontSize={LAYOUT_CONSTANTS.STATION.FONT_SIZE - 2}
                         fontWeight={LAYOUT_CONSTANTS.STATION.FONT_WEIGHT}
@@ -152,6 +156,7 @@ const OsakaMetroSvg = (props: { interchangeInfo: InterchangeInfo; stationType: O
                         {lineCode.toUpperCase()}
                     </text>
                     <text
+                        {...getLangStyle(TextLanguage.berlin)}
                         y={LAYOUT_CONSTANTS.STATION.FONT_SIZE - 2.75}
                         textAnchor="middle"
                         fontSize={LAYOUT_CONSTANTS.STATION.FONT_SIZE - 2}

--- a/src/util/fonts.ts
+++ b/src/util/fonts.ts
@@ -32,6 +32,7 @@ export const Node2Font: {
     [StationType.JREastImportant]: [TextLanguage.jreast_ja, TextLanguage.jreast_en],
     [StationType.TokyoMetroBasic]: [TextLanguage.tokyo_ja, TextLanguage.tokyo_en],
     [StationType.TokyoMetroInt]: [TextLanguage.tokyo_ja, TextLanguage.tokyo_en],
+    [StationType.OsakaMetro]: [TextLanguage.tokyo_ja, TextLanguage.berlin],
     [StationType.LondonTubeBasic]: [TextLanguage.tube],
     [StationType.LondonTubeInt]: [TextLanguage.tube],
     [MiscNodeType.BerlinSBahnLineBadge]: [TextLanguage.berlin],


### PR DESCRIPTION
## Changes

- Explicitly assign the bundled Roboto font to Osaka Metro normal, through-service, two-line station codes, and the station picker icon
- Register Osaka Metro to load both M PLUS 2 for station names and Roboto for station codes
- Add regression coverage for every station-code layout and the font-loading registration

## Root cause

The Osaka Metro station-code SVG text set only a bold weight and did not declare a font family. In `resvg` environments with system fonts disabled, the default fallback font was unavailable, causing station codes to disappear from exported images. Osaka Metro was also missing from `Node2Font`, so its fonts were not reliably loaded or embedded through the node-type font pipeline.

## Impact

Osaka Metro station codes now render consistently with Roboto Bold in both the browser and export environments without system fonts. Fonts are deduplicated at the map level rather than loaded once per station.

## Verification

- `npx tsc --noEmit`
- `npm run lint`
- `npm test -- --run` (49 test files, 323 tests)
- Local `M18` rendering with `resvg --skip-system-fonts --use-fonts-dir public/fonts`
- GitHub Code Quality and CodeQL checks passed

Closes #1554

Related: railmapgen/rmp-gallery#3937